### PR TITLE
Render order

### DIFF
--- a/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs
+++ b/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs
@@ -1,0 +1,59 @@
+﻿
+namespace Pal3.Renderer
+{
+    using UnityEngine;
+
+    public class MaterialFactory
+    {
+
+        private static string kOpaqueShaderPath = "Pal3/Opaque";
+        private static string kTransparentShaderPath = "Pal3/Transparent";
+        
+        private static readonly int _mainTexturePropertyId = Shader.PropertyToID("_MainTex");
+        private static readonly int _tintColorPropertyId = Shader.PropertyToID("_TintColor");
+        private static readonly int _transparentThresholdPropertyId = Shader.PropertyToID("_Threshold");
+        private static readonly int _hasShadowTexPropertyId = Shader.PropertyToID("_HasShadowTex");
+        private static readonly int _shadowTexturePropertyId = Shader.PropertyToID("_ShadowTex");
+
+        public static Material CreateTransparentMaterial(Texture2D mainTexture,
+                                                        Color tintColor,
+                                                        float transparentThreshold,
+                                                        Texture2D shadowTexture = null)
+        {
+            Material material = new Material(Shader.Find(kTransparentShaderPath));
+            material.SetTexture(_mainTexturePropertyId,mainTexture);
+            material.SetColor(_tintColorPropertyId, tintColor);
+            material.SetFloat(_transparentThresholdPropertyId,transparentThreshold);
+            
+            // shadow
+            material.SetFloat(_hasShadowTexPropertyId,0.0f);
+            if (shadowTexture != null)
+            {
+                material.SetFloat(_hasShadowTexPropertyId,1.0f);
+                material.SetTexture(_shadowTexturePropertyId,shadowTexture);
+            }
+            return material;
+        }
+        
+        public static Material CreateOpaqueMaterial(Texture2D mainTexture,
+                                                    Color tintColor,
+                                                    Texture2D shadowTexture = null)
+        {
+            Material material = new Material(Shader.Find(kOpaqueShaderPath));
+            material.SetTexture(_mainTexturePropertyId,mainTexture);
+            material.SetColor(_tintColorPropertyId,tintColor);
+            
+            // shadow
+            material.SetFloat(_hasShadowTexPropertyId,0.0f);
+            if (shadowTexture != null)
+            {
+                material.SetFloat(_hasShadowTexPropertyId,1.0f);
+                material.SetTexture(_shadowTexturePropertyId,shadowTexture);
+            }
+            
+            return material;
+        }
+
+
+    }
+}

--- a/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs.meta
+++ b/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 886dbf38ae7fe41a9a3dad5f53f6aecb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/Pal3_Opaque.shader
+++ b/Assets/Shaders/Pal3_Opaque.shader
@@ -1,0 +1,80 @@
+Shader "Pal3/Opaque"
+{
+    Properties
+    {
+        _MainTex ("Base (RGB) Trans (A)", 2D) = "white" {}
+        //_TintColor ("Tint color", Color) = (1.0, 1.0, 1.0, 1.0)
+        
+        _HasShadowTex ("Has Shadow Texture", Range(0,1)) = 0.0
+        _ShadowTex ("Shadow Texture",2D) = "white" {}
+        _Exposure("Exposure Amount", Range(0.1,1.0)) = 0.4
+    }
+    SubShader
+    {
+        Lighting Off
+        
+        Pass
+        {
+            Tags{"Qeueue" = "Opaque"}
+            Blend Off
+            ZWrite On
+            
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 2.0
+            
+
+            #include "UnityCG.cginc"
+
+            struct appdata_t
+            {
+                float4 vertex : POSITION;
+                float2 texcoord : TEXCOORD0;
+                float2 shadowcoord : TEXCOORD1;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 texcoord : TEXCOORD0;
+                float2 shadowcoord : TEXCOORD1;
+                
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            float4 _TintColor;
+            
+            float _HasShadowTex;
+            sampler2D _ShadowTex;
+            float4 _ShadowTex_ST;
+            float _Exposure;
+            
+            v2f vert(appdata_t v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
+                o.shadowcoord = TRANSFORM_TEX(v.shadowcoord, _ShadowTex);
+                
+                return o;
+            }
+
+            half4 frag(v2f i) : SV_Target
+            {
+                half4 color = tex2D(_MainTex, i.texcoord);
+                if(_HasShadowTex > 0.5f)
+                {
+                    color *= tex2D(_ShadowTex, i.shadowcoord) / (1 - _Exposure);    
+                }
+                return color;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/Pal3_Opaque.shader.meta
+++ b/Assets/Shaders/Pal3_Opaque.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: a83b1b6f4822140d58c7bad4e3b39932
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/Pal3_Transparent.shader
+++ b/Assets/Shaders/Pal3_Transparent.shader
@@ -49,8 +49,8 @@ Shader "Pal3/Transparent"
             sampler2D _MainTex;
             float4 _MainTex_ST;
             float _Threshold;
-            float _HasShadowTex;
             
+            float _HasShadowTex;
             sampler2D _ShadowTex;
             float4 _ShadowTex_ST;
             float _Exposure;
@@ -71,12 +71,12 @@ Shader "Pal3/Transparent"
             {
                 half4 color = tex2D(_MainTex, i.texcoord);
                 clip(color.a - _Threshold);
-                
+
                 if(_HasShadowTex > 0.5f)
                 {
                     color *= tex2D(_ShadowTex, i.shadowcoord) / (1 - _Exposure);    
                 }
-                
+                                
                 return color;
             }
             ENDCG
@@ -117,6 +117,12 @@ Shader "Pal3/Transparent"
             sampler2D _MainTex;
             float4 _MainTex_ST;
             float _Threshold;
+
+            
+            float _HasShadowTex;
+            sampler2D _ShadowTex;
+            float4 _ShadowTex_ST;
+            float _Exposure;
             
             v2f vert(appdata_t v)
             {
@@ -125,17 +131,25 @@ Shader "Pal3/Transparent"
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
-                
+                o.shadowcoord = TRANSFORM_TEX(v.shadowcoord, _ShadowTex);
                 return o;
             }
 
             half4 frag(v2f i) : SV_Target
             {
                 half4 color = tex2D(_MainTex, i.texcoord);
+                float alpha = color.a;
                 if(color.a >= _Threshold)
                 {
                     discard;
                 }
+                
+                if(_HasShadowTex > 0.5f)
+                {
+                    color *= tex2D(_ShadowTex, i.shadowcoord) / (1 - _Exposure);
+                    color.a = alpha;
+                }
+                
                 return color;
             }
             ENDCG

--- a/Assets/Shaders/Pal3_Transparent.shader
+++ b/Assets/Shaders/Pal3_Transparent.shader
@@ -1,0 +1,144 @@
+Shader "Pal3/Transparent"
+{
+    Properties
+    {
+        _MainTex ("Base (RGB) Trans (A)", 2D) = "white" {}
+        _Threshold ("Transparent Threshold", Range(0,1)) = 1.0
+        
+        
+        _HasShadowTex ("Has Shadow Texture", Range(0,1)) = 0.0
+        _ShadowTex ("Shadow Texture",2D) = "white" {}
+        _Exposure("Exposure Amount", Range(0.1,1.0)) = 0.4
+    }
+    SubShader
+    {
+        Lighting Off
+        
+        // pass 1 , opaque part
+        Pass
+        {
+            Tags{"Qeueue" = "Opaque"}
+            Blend Off
+            ZWrite On
+            
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 2.0
+            
+
+            #include "UnityCG.cginc"
+
+            struct appdata_t
+            {
+                float4 vertex : POSITION;
+                float2 texcoord : TEXCOORD0;
+                float2 shadowcoord : TEXCOORD1;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 texcoord : TEXCOORD0;
+                float2 shadowcoord : TEXCOORD1;
+                
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            float _Threshold;
+            float _HasShadowTex;
+            
+            sampler2D _ShadowTex;
+            float4 _ShadowTex_ST;
+            float _Exposure;
+
+            v2f vert(appdata_t v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
+                o.shadowcoord = TRANSFORM_TEX(v.shadowcoord, _ShadowTex);
+                
+                return o;
+            }
+
+            half4 frag(v2f i) : SV_Target
+            {
+                half4 color = tex2D(_MainTex, i.texcoord);
+                clip(color.a - _Threshold);
+                
+                if(_HasShadowTex > 0.5f)
+                {
+                    color *= tex2D(_ShadowTex, i.shadowcoord) / (1 - _Exposure);    
+                }
+                
+                return color;
+            }
+            ENDCG
+        }
+        
+        // Pass 2 ,transparent part
+        Pass
+        {
+            Tags{"Qeueue" = "Transparent"}
+            Blend SrcAlpha OneMinusSrcAlpha
+            ZWrite Off
+            
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 2.0
+            
+
+            #include "UnityCG.cginc"
+
+            struct appdata_t
+            {
+                float4 vertex : POSITION;
+                float2 texcoord : TEXCOORD0;
+                float2 shadowcoord : TEXCOORD1;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 texcoord : TEXCOORD0;
+                float2 shadowcoord : TEXCOORD1;
+                
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            float _Threshold;
+            
+            v2f vert(appdata_t v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
+                
+                return o;
+            }
+
+            half4 frag(v2f i) : SV_Target
+            {
+                half4 color = tex2D(_MainTex, i.texcoord);
+                if(color.a >= _Threshold)
+                {
+                    discard;
+                }
+                return color;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/Pal3_Transparent.shader.meta
+++ b/Assets/Shaders/Pal3_Transparent.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 9a73f8d5b84814e63a97995e839fdabb
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
[https://bytedance.feishu.cn/docx/I4SudJcDTovqHyx94f9claVPnQc](url)

修改了不透明物体、半透明物体绘制顺序。
几个边界测试case 和修改效果，详见上面的链接

mv3, poly, cvd 几个 renderer 的 材质创建，都交给 MaterialFactory来管理。
原Pal3Standard Pal3StandardNoShadow 两个 shader 不再起作用，
取代之的是
Pal3_Opaque.shader 用于绘制纯不透明物体
Pal3_Transparent.shader 用2个pass 分别绘制半透明物体的 “不透明部分” 和 ”半透明部分“
修改了之前强行设置 material  renderqueue 导致的几个 渲染层级 bug 

下面这2个 commit 要一起使用才生效

![image](https://user-images.githubusercontent.com/8259193/195415476-9e6f61da-4e06-48a9-b4ee-054ba29ba542.png)
