### PR TITLE
Render order

### DIFF
--- a/Assets/Scripts/Core/Renderer/StaticMeshRenderer.cs
+++ b/Assets/Scripts/Core/Renderer/StaticMeshRenderer.cs
@@ -12,7 +12,8 @@ namespace Core.Renderer
     {
         private MeshRenderer _meshRenderer;
         private MeshFilter _meshFilter;
-
+    
+            /*
         public Mesh Render(ref Vector3[] vertices,
             ref int[] triangles,
             ref Vector3[] normals,
@@ -53,6 +54,7 @@ namespace Core.Renderer
 
             return mesh;
         }
+        */
 
         /*
         public Mesh Render(ref Vector3[] vertices,
@@ -78,8 +80,7 @@ namespace Core.Renderer
             bool isDynamic)
         {
             Mesh mesh = RenderInternal(ref vertices,ref triangles,ref normals,ref mainTextureUv,ref secondaryTextureUv,isDynamic);
-            _meshRenderer.materials = materials;
-            
+            _meshRenderer.sharedMaterials = materials;
             return mesh;
         }
 
@@ -161,9 +162,9 @@ namespace Core.Renderer
 
             if (_meshRenderer != null)
             {
-                for (int i = 0;i < _meshRenderer.materials.Length;i++)
+                for (int i = 0;i < _meshRenderer.sharedMaterials.Length;i++)
                 {
-                    Destroy(_meshRenderer.materials[i]);
+                    Destroy(_meshRenderer.sharedMaterials[i]);
                 }
                 Destroy(_meshRenderer);
             }

--- a/Assets/Scripts/Core/Renderer/StaticMeshRenderer.cs
+++ b/Assets/Scripts/Core/Renderer/StaticMeshRenderer.cs
@@ -54,6 +54,7 @@ namespace Core.Renderer
             return mesh;
         }
 
+        /*
         public Mesh Render(ref Vector3[] vertices,
             ref int[] triangles,
             ref Vector3[] normals,
@@ -62,12 +63,40 @@ namespace Core.Renderer
             ref Material material,
             bool isDynamic)
         {
+            Mesh mesh = RenderInternal(ref vertices,ref triangles,ref normals,ref mainTextureUv,ref secondaryTextureUv,isDynamic);
+            _meshRenderer.sharedMaterial = material;
+            return mesh;
+        }
+        */
+        
+        public Mesh RenderWithMaterials(ref Vector3[] vertices,
+            ref int[] triangles,
+            ref Vector3[] normals,
+            ref Vector2[] mainTextureUv,
+            ref Vector2[] secondaryTextureUv,
+            ref Material[] materials,
+            bool isDynamic)
+        {
+            Mesh mesh = RenderInternal(ref vertices,ref triangles,ref normals,ref mainTextureUv,ref secondaryTextureUv,isDynamic);
+            _meshRenderer.materials = materials;
+            
+            return mesh;
+        }
+
+        private Mesh RenderInternal(ref Vector3[] vertices,
+            ref int[] triangles,
+            ref Vector3[] normals,
+            ref Vector2[] mainTextureUv,
+            ref Vector2[] secondaryTextureUv,
+            bool isDynamic)
+        {
             Dispose();
 
             _meshRenderer = gameObject.AddComponent<MeshRenderer>();
             //_meshRenderer.receiveShadows = false;
             //_meshRenderer.lightProbeUsage = LightProbeUsage.Off;
-            _meshRenderer.sharedMaterial = material;
+            //_meshRenderer.sharedMaterial = material;
+            
 
             _meshFilter = gameObject.AddComponent<MeshFilter>();
             var mesh = new Mesh();
@@ -95,6 +124,7 @@ namespace Core.Renderer
 
             return mesh;
         }
+    
 
         public Mesh GetMesh()
         {
@@ -131,7 +161,10 @@ namespace Core.Renderer
 
             if (_meshRenderer != null)
             {
-                Destroy(_meshRenderer.sharedMaterial);
+                for (int i = 0;i < _meshRenderer.materials.Length;i++)
+                {
+                    Destroy(_meshRenderer.materials[i]);
+                }
                 Destroy(_meshRenderer);
             }
         }

--- a/Assets/Scripts/Pal3/Renderer/CvdModelRenderer.cs
+++ b/Assets/Scripts/Pal3/Renderer/CvdModelRenderer.cs
@@ -181,11 +181,11 @@ namespace Pal3.Renderer
                     bool bTransparent = (meshSection.BlendFlag == 1);
                     if (bTransparent)
                     {
-                        material = MaterialFactory.CreateTransparentMaterial(textureCache[meshSection.TextureName],_tintColor,TRANSPARENT_THRESHOLD);
+                        material = MaterialFactory.CreateTransparentMaterial(textureCache[meshSection.TextureName],_tintColor,TRANSPARENT_THRESHOLD,null);
                     }
                     else
                     {
-                        material = MaterialFactory.CreateOpaqueMaterial(textureCache[meshSection.TextureName],_tintColor);
+                        material = MaterialFactory.CreateOpaqueMaterial(textureCache[meshSection.TextureName],_tintColor,null);
                     }
 
                     var triangles = GameBoxInterpreter.ToUnityTriangles(meshSection.Triangles);

--- a/Assets/Scripts/Pal3/Renderer/CvdModelRenderer.cs
+++ b/Assets/Scripts/Pal3/Renderer/CvdModelRenderer.cs
@@ -182,7 +182,9 @@ namespace Pal3.Renderer
                     
                     //Material material = null;
                     bool bTransparent = (meshSection.BlendFlag == 1);
-                    Material[] materials = MaterialFactory.CreateMaterials(textureCache[meshSection.TextureName],
+                    Material[] materials = MaterialFactory.CreateMaterials(
+                        MaterialFactory.EMeshType.Cvd,
+                        textureCache[meshSection.TextureName],
                         null,
                         _tintColor,
                         bTransparent,

--- a/Assets/Scripts/Pal3/Renderer/CvdModelRenderer.cs
+++ b/Assets/Scripts/Pal3/Renderer/CvdModelRenderer.cs
@@ -3,6 +3,8 @@
 //  See LICENSE file in the project root for license information.
 // ---------------------------------------------------------------------------------------------
 
+using UnityEngine.Animations;
+
 namespace Pal3.Renderer
 {
     using System;
@@ -143,7 +145,7 @@ namespace Pal3.Renderer
                                 (node.Mesh.AnimationTimeKeys[frameIndex + 1] -
                                  node.Mesh.AnimationTimeKeys[frameIndex]);
                 }
-
+                
                 for (var i = 0; i < node.Mesh.MeshSections.Length; i++)
                 {
                     CvdMeshSection meshSection = node.Mesh.MeshSections[i];
@@ -175,26 +177,25 @@ namespace Pal3.Renderer
                     materialInfoPresenter.material = meshSection.Material;
                     #endif
 
-                    var meshRenderer = meshSectionObject.AddComponent<StaticMeshRenderer>();
-
-                    Material material = null;
-                    bool bTransparent = (meshSection.BlendFlag == 1);
-                    if (bTransparent)
-                    {
-                        material = MaterialFactory.CreateTransparentMaterial(textureCache[meshSection.TextureName],_tintColor,TRANSPARENT_THRESHOLD,null);
-                    }
-                    else
-                    {
-                        material = MaterialFactory.CreateOpaqueMaterial(textureCache[meshSection.TextureName],_tintColor,null);
-                    }
-
                     var triangles = GameBoxInterpreter.ToUnityTriangles(meshSection.Triangles);
 
-                    Mesh renderMesh = meshRenderer.Render(ref meshDataBuffer.VertexBuffer,
-                        ref triangles,
+                    
+                    //Material material = null;
+                    bool bTransparent = (meshSection.BlendFlag == 1);
+                    Material[] materials = MaterialFactory.CreateMaterials(textureCache[meshSection.TextureName],
+                        null,
+                        _tintColor,
+                        bTransparent,
+                        TRANSPARENT_THRESHOLD);
+                    
+                    var meshRenderer = meshSectionObject.AddComponent<StaticMeshRenderer>();
+                    Mesh renderMesh = meshRenderer.RenderWithMaterials(
+                        ref meshDataBuffer.VertexBuffer,
+                                ref triangles,
                         ref meshDataBuffer.NormalBuffer,
-                        ref meshDataBuffer.UvBuffer,
-                        ref material,
+                    ref meshDataBuffer.UvBuffer,
+                ref meshDataBuffer.UvBuffer,
+                                ref materials,
                         true);
 
                     nodeMeshes.Item2[i] = new RenderMeshComponent

--- a/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs
+++ b/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs
@@ -3,7 +3,7 @@ namespace Pal3.Renderer
 {
     using UnityEngine;
 
-    public class MaterialFactory
+    public static class MaterialFactory
     {
 
         private static string kOpaqueShaderPath = "Pal3/Opaque";
@@ -18,7 +18,7 @@ namespace Pal3.Renderer
         public static Material CreateTransparentMaterial(Texture2D mainTexture,
                                                         Color tintColor,
                                                         float transparentThreshold,
-                                                        Texture2D shadowTexture = null)
+                                                        Texture2D shadowTexture)
         {
             Material material = new Material(Shader.Find(kTransparentShaderPath));
             material.SetTexture(_mainTexturePropertyId,mainTexture);
@@ -37,7 +37,7 @@ namespace Pal3.Renderer
         
         public static Material CreateOpaqueMaterial(Texture2D mainTexture,
                                                     Color tintColor,
-                                                    Texture2D shadowTexture = null)
+                                                    Texture2D shadowTexture)
         {
             Material material = new Material(Shader.Find(kOpaqueShaderPath));
             material.SetTexture(_mainTexturePropertyId,mainTexture);

--- a/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs
+++ b/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs
@@ -8,14 +8,39 @@ namespace Pal3.Renderer
 
         private static string kOpaqueShaderPath = "Pal3/Opaque";
         private static string kTransparentShaderPath = "Pal3/Transparent";
-        
+        private static string kTransparentOpaquePartShaderPath = "Pal3/TransparentOpaquePart";
+
         private static readonly int _mainTexturePropertyId = Shader.PropertyToID("_MainTex");
         private static readonly int _tintColorPropertyId = Shader.PropertyToID("_TintColor");
         private static readonly int _transparentThresholdPropertyId = Shader.PropertyToID("_Threshold");
         private static readonly int _hasShadowTexPropertyId = Shader.PropertyToID("_HasShadowTex");
         private static readonly int _shadowTexturePropertyId = Shader.PropertyToID("_ShadowTex");
 
-        public static Material CreateTransparentMaterial(Texture2D mainTexture,
+
+        public static Material[] CreateMaterials(Texture2D mainTexture,
+                                                Texture2D shadowTexture,
+                                                Color tintColor,
+                                                bool bTransparent,
+                                                float transparentThreshold)
+        {
+            Material[] result = null;
+            if (bTransparent)
+            {
+                result = new Material[2];
+                result[0] = CreateTransparentOpaquePartMaterial(mainTexture,tintColor,transparentThreshold,shadowTexture);
+                result[1] = CreateTransparentMaterial(mainTexture,tintColor,transparentThreshold,shadowTexture);
+            }
+            else
+            {
+                result = new Material[1];
+                result[0] = CreateOpaqueMaterial(mainTexture,tintColor,shadowTexture);
+            }
+            return result;
+        }
+        
+        
+
+        private static Material CreateTransparentMaterial(Texture2D mainTexture,
                                                         Color tintColor,
                                                         float transparentThreshold,
                                                         Texture2D shadowTexture)
@@ -35,7 +60,27 @@ namespace Pal3.Renderer
             return material;
         }
         
-        public static Material CreateOpaqueMaterial(Texture2D mainTexture,
+        private static Material CreateTransparentOpaquePartMaterial(Texture2D mainTexture,
+            Color tintColor,
+            float transparentThreshold,
+            Texture2D shadowTexture)
+        {
+            Material material = new Material(Shader.Find(kTransparentOpaquePartShaderPath));
+            material.SetTexture(_mainTexturePropertyId,mainTexture);
+            material.SetColor(_tintColorPropertyId, tintColor);
+            material.SetFloat(_transparentThresholdPropertyId,transparentThreshold);
+            
+            // shadow
+            material.SetFloat(_hasShadowTexPropertyId,0.0f);
+            if (shadowTexture != null)
+            {
+                material.SetFloat(_hasShadowTexPropertyId,1.0f);
+                material.SetTexture(_shadowTexturePropertyId,shadowTexture);
+            }
+            return material;
+        }
+        
+        private static Material CreateOpaqueMaterial(Texture2D mainTexture,
                                                     Color tintColor,
                                                     Texture2D shadowTexture)
         {

--- a/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs
+++ b/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs
@@ -5,6 +5,12 @@ namespace Pal3.Renderer
 
     public static class MaterialFactory
     {
+        public enum EMeshType
+        {
+            Poly,
+            Mv3,
+            Cvd,
+        }
 
         private static string kOpaqueShaderPath = "Pal3/Opaque";
         private static string kTransparentShaderPath = "Pal3/Transparent";
@@ -17,7 +23,8 @@ namespace Pal3.Renderer
         private static readonly int _shadowTexturePropertyId = Shader.PropertyToID("_ShadowTex");
 
 
-        public static Material[] CreateMaterials(Texture2D mainTexture,
+        public static Material[] CreateMaterials(EMeshType meshType,
+                                                Texture2D mainTexture,
                                                 Texture2D shadowTexture,
                                                 Color tintColor,
                                                 bool bTransparent,
@@ -38,8 +45,6 @@ namespace Pal3.Renderer
             return result;
         }
         
-        
-
         private static Material CreateTransparentMaterial(Texture2D mainTexture,
                                                         Color tintColor,
                                                         float transparentThreshold,

--- a/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs
+++ b/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs
@@ -1,0 +1,59 @@
+﻿
+namespace Pal3.Renderer
+{
+    using UnityEngine;
+
+    public class MaterialFactory
+    {
+
+        private static string kOpaqueShaderPath = "Pal3/Opaque";
+        private static string kTransparentShaderPath = "Pal3/Transparent";
+        
+        private static readonly int _mainTexturePropertyId = Shader.PropertyToID("_MainTex");
+        private static readonly int _tintColorPropertyId = Shader.PropertyToID("_TintColor");
+        private static readonly int _transparentThresholdPropertyId = Shader.PropertyToID("_Threshold");
+        private static readonly int _hasShadowTexPropertyId = Shader.PropertyToID("_HasShadowTex");
+        private static readonly int _shadowTexturePropertyId = Shader.PropertyToID("_ShadowTex");
+
+        public static Material CreateTransparentMaterial(Texture2D mainTexture,
+                                                        Color tintColor,
+                                                        float transparentThreshold,
+                                                        Texture2D shadowTexture = null)
+        {
+            Material material = new Material(Shader.Find(kTransparentShaderPath));
+            material.SetTexture(_mainTexturePropertyId,mainTexture);
+            material.SetColor(_tintColorPropertyId, tintColor);
+            material.SetFloat(_transparentThresholdPropertyId,transparentThreshold);
+            
+            // shadow
+            material.SetFloat(_hasShadowTexPropertyId,0.0f);
+            if (shadowTexture != null)
+            {
+                material.SetFloat(_hasShadowTexPropertyId,1.0f);
+                material.SetTexture(_shadowTexturePropertyId,shadowTexture);
+            }
+            return material;
+        }
+        
+        public static Material CreateOpaqueMaterial(Texture2D mainTexture,
+                                                    Color tintColor,
+                                                    Texture2D shadowTexture = null)
+        {
+            Material material = new Material(Shader.Find(kOpaqueShaderPath));
+            material.SetTexture(_mainTexturePropertyId,mainTexture);
+            material.SetColor(_tintColorPropertyId,tintColor);
+            
+            // shadow
+            material.SetFloat(_hasShadowTexPropertyId,0.0f);
+            if (shadowTexture != null)
+            {
+                material.SetFloat(_hasShadowTexPropertyId,1.0f);
+                material.SetTexture(_shadowTexturePropertyId,shadowTexture);
+            }
+            
+            return material;
+        }
+
+
+    }
+}

--- a/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs.meta
+++ b/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 886dbf38ae7fe41a9a3dad5f53f6aecb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pal3/Renderer/Mv3ModelRenderer.cs
+++ b/Assets/Scripts/Pal3/Renderer/Mv3ModelRenderer.cs
@@ -32,8 +32,7 @@ namespace Pal3.Renderer
         private const float TIME_TO_TICK_SCALE = 5000f;
 
         private readonly int _mainTexturePropertyId = Shader.PropertyToID("_MainTex");
-                
-
+        
         private ITextureResourceProvider _textureProvider;
         private VertexAnimationKeyFrame[][] _keyFrames;
         private Texture2D[] _textures;

--- a/Assets/Scripts/Pal3/Renderer/Mv3ModelRenderer.cs
+++ b/Assets/Scripts/Pal3/Renderer/Mv3ModelRenderer.cs
@@ -151,7 +151,13 @@ namespace Pal3.Renderer
             
             bool bTransparent = _textureHasAlphaChannel[index];
             
-            Material[] mats = MaterialFactory.CreateMaterials(_textures[index],null,_tintColor,bTransparent,TRANSPARENT_THRESHOLD);
+            Material[] mats = MaterialFactory.CreateMaterials(
+                MaterialFactory.EMeshType.Mv3,
+                _textures[index],
+                null,
+                _tintColor,
+                bTransparent,
+                TRANSPARENT_THRESHOLD);
             _materials[index] = mats[0];    // @miao todo .only hold the 1st material 
             
             #if PAL3A
@@ -170,14 +176,6 @@ namespace Pal3.Renderer
             };
 
             var normals = Array.Empty<Vector3>();
-
-            // Mesh renderMesh = meshRenderer.Render(ref _keyFrames[index][0].Vertices,
-            //     ref _keyFrames[index][0].Triangles,
-            //     ref normals,
-            //     ref _keyFrames[index][0].Uv,
-            //     ref _materials[index],
-            //     true);
-            
             Mesh renderMesh = meshRenderer.RenderWithMaterials(ref _keyFrames[index][0].Vertices,
                 ref _keyFrames[index][0].Triangles,
                 ref normals,

--- a/Assets/Scripts/Pal3/Renderer/Mv3ModelRenderer.cs
+++ b/Assets/Scripts/Pal3/Renderer/Mv3ModelRenderer.cs
@@ -149,18 +149,11 @@ namespace Pal3.Renderer
             #endif
 
             var meshRenderer = _meshObjects[index].AddComponent<StaticMeshRenderer>();
-
-
-            bool bTransparent = _textureHasAlphaChannel[index];
-            if (bTransparent)
-            {
-                _materials[index] = MaterialFactory.CreateTransparentMaterial(_textures[index],_tintColor,TRANSPARENT_THRESHOLD,null);
-            }
-            else
-            {
-                _materials[index] = MaterialFactory.CreateOpaqueMaterial(_textures[index],_tintColor,null);                
-            }
             
+            bool bTransparent = _textureHasAlphaChannel[index];
+            
+            Material[] mats = MaterialFactory.CreateMaterials(_textures[index],null,_tintColor,bTransparent,TRANSPARENT_THRESHOLD);
+            _materials[index] = mats[0];    // @miao todo .only hold the 1st material 
             
             #if PAL3A
             // Apply PAL3A texture scaling/tiling fix
@@ -179,12 +172,20 @@ namespace Pal3.Renderer
 
             var normals = Array.Empty<Vector3>();
 
-            Mesh renderMesh = meshRenderer.Render(ref _keyFrames[index][0].Vertices,
+            // Mesh renderMesh = meshRenderer.Render(ref _keyFrames[index][0].Vertices,
+            //     ref _keyFrames[index][0].Triangles,
+            //     ref normals,
+            //     ref _keyFrames[index][0].Uv,
+            //     ref _materials[index],
+            //     true);
+            
+            Mesh renderMesh = meshRenderer.RenderWithMaterials(ref _keyFrames[index][0].Vertices,
                 ref _keyFrames[index][0].Triangles,
                 ref normals,
                 ref _keyFrames[index][0].Uv,
-                ref _materials[index],
-                true);
+            ref _keyFrames[index][0].Uv,
+                ref mats,
+                true);            
 
             //renderMesh.RecalculateNormals();
             //renderMesh.RecalculateTangents();
@@ -223,6 +224,9 @@ namespace Pal3.Renderer
             _textures[0] = _textureProvider.GetTexture(textureName, out var hasAlphaChannel);
             _materials[0].SetTexture(_mainTexturePropertyId, _textures[0]);
             _textureHasAlphaChannel[0] = hasAlphaChannel;
+            
+            // @miao todo
+            // should also change reference material,not only the main material
         }
 
         public void PauseAnimation()

--- a/Assets/Scripts/Pal3/Renderer/Mv3ModelRenderer.cs
+++ b/Assets/Scripts/Pal3/Renderer/Mv3ModelRenderer.cs
@@ -154,11 +154,11 @@ namespace Pal3.Renderer
             bool bTransparent = _textureHasAlphaChannel[index];
             if (bTransparent)
             {
-                _materials[index] = MaterialFactory.CreateTransparentMaterial(_textures[index],_tintColor,TRANSPARENT_THRESHOLD);
+                _materials[index] = MaterialFactory.CreateTransparentMaterial(_textures[index],_tintColor,TRANSPARENT_THRESHOLD,null);
             }
             else
             {
-                _materials[index] = MaterialFactory.CreateOpaqueMaterial(_textures[index],_tintColor);                
+                _materials[index] = MaterialFactory.CreateOpaqueMaterial(_textures[index],_tintColor,null);                
             }
             
             
@@ -222,7 +222,6 @@ namespace Pal3.Renderer
             // Change the texture for the first sub-mesh only
             _textures[0] = _textureProvider.GetTexture(textureName, out var hasAlphaChannel);
             _materials[0].SetTexture(_mainTexturePropertyId, _textures[0]);
-            //_materials[0].SetFloat(_cutoffPropertyId, hasAlphaChannel ? 0.3f : 0f);
             _textureHasAlphaChannel[0] = hasAlphaChannel;
         }
 

--- a/Assets/Scripts/Pal3/Renderer/PolyModelRenderer.cs
+++ b/Assets/Scripts/Pal3/Renderer/PolyModelRenderer.cs
@@ -152,7 +152,11 @@ namespace Pal3.Renderer
 
                     if (isWaterSurface)
                     {
-                        StartWaterSurfaceAnimation(mats[0], textures[0].texture);
+                        //StartWaterSurfaceAnimation(mats[0], textures[0].texture);
+                        foreach(Material mat in mats)
+                        {
+                            StartWaterSurfaceAnimation(mat, textures[0].texture);       
+                        }
                     }
                 }
                 else if (textures.Count >= 2)
@@ -165,9 +169,8 @@ namespace Pal3.Renderer
                     var isWaterSurface = textures[1].name
                         .StartsWith(ANIMATED_WATER_TEXTURE_DEFAULT_NAME, StringComparison.OrdinalIgnoreCase);
 
-                    // here should handle shadow
+                    
                     bool bTransparent = blendFlag is 1 or 2;
-
                     Material[] mats = MaterialFactory.CreateMaterials(
                         MaterialFactory.EMeshType.Poly,
                         textures[1].texture,
@@ -187,7 +190,10 @@ namespace Pal3.Renderer
 
                     if (isWaterSurface)
                     {
-                        StartWaterSurfaceAnimation(mats[0], textures[1].texture);
+                        foreach(Material mat in mats)
+                        {
+                            StartWaterSurfaceAnimation(mat, textures[1].texture);       
+                        }
                     }
                 }
 

--- a/Assets/Scripts/Pal3/Renderer/PolyModelRenderer.cs
+++ b/Assets/Scripts/Pal3/Renderer/PolyModelRenderer.cs
@@ -141,11 +141,11 @@ namespace Pal3.Renderer
                         bool bTransparent = blendFlag is 1 or 2;
                         if (bTransparent)
                         {
-                            material = MaterialFactory.CreateTransparentMaterial(textures[0].texture,_tintColor,NOSHADOW_TRANSPARENT_THRESHOLD);
+                            material = MaterialFactory.CreateTransparentMaterial(textures[0].texture,_tintColor,NOSHADOW_TRANSPARENT_THRESHOLD,null);
                         }
                         else
                         {
-                            material = MaterialFactory.CreateOpaqueMaterial(textures[0].texture,_tintColor);
+                            material = MaterialFactory.CreateOpaqueMaterial(textures[0].texture,_tintColor,null);
                         }
                         
                         _materials[materialHashKey] = material;

--- a/Assets/Scripts/Pal3/Renderer/PolyModelRenderer.cs
+++ b/Assets/Scripts/Pal3/Renderer/PolyModelRenderer.cs
@@ -133,8 +133,13 @@ namespace Pal3.Renderer
                     
                     bool bTransparent = blendFlag is 1 or 2;
                     
-                    Material[] mats = MaterialFactory.CreateMaterials(textures[0].texture,null,
-                                                                _tintColor,bTransparent,NOSHADOW_TRANSPARENT_THRESHOLD);
+                    Material[] mats = MaterialFactory.CreateMaterials(
+                        MaterialFactory.EMeshType.Poly,
+                        textures[0].texture,
+                        null,
+                        _tintColor,
+                        bTransparent,
+                        NOSHADOW_TRANSPARENT_THRESHOLD);
                                                 
                     
                     _ = meshRenderer.RenderWithMaterials(ref mesh.VertexInfo.Positions,
@@ -163,7 +168,9 @@ namespace Pal3.Renderer
                     // here should handle shadow
                     bool bTransparent = blendFlag is 1 or 2;
 
-                    Material[] mats = MaterialFactory.CreateMaterials(textures[1].texture,
+                    Material[] mats = MaterialFactory.CreateMaterials(
+                        MaterialFactory.EMeshType.Poly,
+                        textures[1].texture,
                         textures[0].texture,
                         _tintColor,
                         bTransparent,

--- a/Assets/Shaders/Pal3_Opaque.shader
+++ b/Assets/Shaders/Pal3_Opaque.shader
@@ -12,10 +12,11 @@ Shader "Pal3/Opaque"
     SubShader
     {
         Lighting Off
+        Tags{"QUEUE" = "Geometry"}
         
         Pass
         {
-            Tags{"Qeueue" = "Opaque"}
+            Tags{"Qeueue" = "Geometry"}
             Blend Off
             ZWrite On
             
@@ -68,6 +69,8 @@ Shader "Pal3/Opaque"
             half4 frag(v2f i) : SV_Target
             {
                 half4 color = tex2D(_MainTex, i.texcoord);
+
+                //return half4(0.0,1.0,0.0,1.0);
                 if(_HasShadowTex > 0.5f)
                 {
                     color *= tex2D(_ShadowTex, i.shadowcoord) / (1 - _Exposure);    

--- a/Assets/Shaders/Pal3_Opaque.shader
+++ b/Assets/Shaders/Pal3_Opaque.shader
@@ -1,0 +1,80 @@
+Shader "Pal3/Opaque"
+{
+    Properties
+    {
+        _MainTex ("Base (RGB) Trans (A)", 2D) = "white" {}
+        //_TintColor ("Tint color", Color) = (1.0, 1.0, 1.0, 1.0)
+        
+        _HasShadowTex ("Has Shadow Texture", Range(0,1)) = 0.0
+        _ShadowTex ("Shadow Texture",2D) = "white" {}
+        _Exposure("Exposure Amount", Range(0.1,1.0)) = 0.4
+    }
+    SubShader
+    {
+        Lighting Off
+        
+        Pass
+        {
+            Tags{"Qeueue" = "Opaque"}
+            Blend Off
+            ZWrite On
+            
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 2.0
+            
+
+            #include "UnityCG.cginc"
+
+            struct appdata_t
+            {
+                float4 vertex : POSITION;
+                float2 texcoord : TEXCOORD0;
+                float2 shadowcoord : TEXCOORD1;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 texcoord : TEXCOORD0;
+                float2 shadowcoord : TEXCOORD1;
+                
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            float4 _TintColor;
+            
+            float _HasShadowTex;
+            sampler2D _ShadowTex;
+            float4 _ShadowTex_ST;
+            float _Exposure;
+            
+            v2f vert(appdata_t v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
+                o.shadowcoord = TRANSFORM_TEX(v.shadowcoord, _ShadowTex);
+                
+                return o;
+            }
+
+            half4 frag(v2f i) : SV_Target
+            {
+                half4 color = tex2D(_MainTex, i.texcoord);
+                if(_HasShadowTex > 0.5f)
+                {
+                    color *= tex2D(_ShadowTex, i.shadowcoord) / (1 - _Exposure);    
+                }
+                return color;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/Pal3_Opaque.shader
+++ b/Assets/Shaders/Pal3_Opaque.shader
@@ -3,7 +3,7 @@ Shader "Pal3/Opaque"
     Properties
     {
         _MainTex ("Base (RGB) Trans (A)", 2D) = "white" {}
-        //_TintColor ("Tint color", Color) = (1.0, 1.0, 1.0, 1.0)
+        _TintColor ("Tint color", Color) = (1.0, 1.0, 1.0, 1.0)
         
         _HasShadowTex ("Has Shadow Texture", Range(0,1)) = 0.0
         _ShadowTex ("Shadow Texture",2D) = "white" {}
@@ -75,6 +75,7 @@ Shader "Pal3/Opaque"
                 {
                     color *= tex2D(_ShadowTex, i.shadowcoord) / (1 - _Exposure);    
                 }
+                color *= _TintColor;
                 return color;
             }
             ENDCG

--- a/Assets/Shaders/Pal3_Opaque.shader.meta
+++ b/Assets/Shaders/Pal3_Opaque.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: a83b1b6f4822140d58c7bad4e3b39932
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/Pal3_Transparent.shader
+++ b/Assets/Shaders/Pal3_Transparent.shader
@@ -49,8 +49,8 @@ Shader "Pal3/Transparent"
             sampler2D _MainTex;
             float4 _MainTex_ST;
             float _Threshold;
-            float _HasShadowTex;
             
+            float _HasShadowTex;
             sampler2D _ShadowTex;
             float4 _ShadowTex_ST;
             float _Exposure;
@@ -71,12 +71,12 @@ Shader "Pal3/Transparent"
             {
                 half4 color = tex2D(_MainTex, i.texcoord);
                 clip(color.a - _Threshold);
-                
+
                 if(_HasShadowTex > 0.5f)
                 {
                     color *= tex2D(_ShadowTex, i.shadowcoord) / (1 - _Exposure);    
                 }
-                
+                                
                 return color;
             }
             ENDCG
@@ -117,6 +117,12 @@ Shader "Pal3/Transparent"
             sampler2D _MainTex;
             float4 _MainTex_ST;
             float _Threshold;
+
+            
+            float _HasShadowTex;
+            sampler2D _ShadowTex;
+            float4 _ShadowTex_ST;
+            float _Exposure;
             
             v2f vert(appdata_t v)
             {
@@ -125,17 +131,25 @@ Shader "Pal3/Transparent"
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
-                
+                o.shadowcoord = TRANSFORM_TEX(v.shadowcoord, _ShadowTex);
                 return o;
             }
 
             half4 frag(v2f i) : SV_Target
             {
                 half4 color = tex2D(_MainTex, i.texcoord);
+                float alpha = color.a;
                 if(color.a >= _Threshold)
                 {
                     discard;
                 }
+                
+                if(_HasShadowTex > 0.5f)
+                {
+                    color *= tex2D(_ShadowTex, i.shadowcoord) / (1 - _Exposure);
+                    color.a = alpha;
+                }
+                
                 return color;
             }
             ENDCG

--- a/Assets/Shaders/Pal3_Transparent.shader
+++ b/Assets/Shaders/Pal3_Transparent.shader
@@ -1,0 +1,144 @@
+Shader "Pal3/Transparent"
+{
+    Properties
+    {
+        _MainTex ("Base (RGB) Trans (A)", 2D) = "white" {}
+        _Threshold ("Transparent Threshold", Range(0,1)) = 1.0
+        
+        
+        _HasShadowTex ("Has Shadow Texture", Range(0,1)) = 0.0
+        _ShadowTex ("Shadow Texture",2D) = "white" {}
+        _Exposure("Exposure Amount", Range(0.1,1.0)) = 0.4
+    }
+    SubShader
+    {
+        Lighting Off
+        
+        // pass 1 , opaque part
+        Pass
+        {
+            Tags{"Qeueue" = "Opaque"}
+            Blend Off
+            ZWrite On
+            
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 2.0
+            
+
+            #include "UnityCG.cginc"
+
+            struct appdata_t
+            {
+                float4 vertex : POSITION;
+                float2 texcoord : TEXCOORD0;
+                float2 shadowcoord : TEXCOORD1;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 texcoord : TEXCOORD0;
+                float2 shadowcoord : TEXCOORD1;
+                
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            float _Threshold;
+            float _HasShadowTex;
+            
+            sampler2D _ShadowTex;
+            float4 _ShadowTex_ST;
+            float _Exposure;
+
+            v2f vert(appdata_t v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
+                o.shadowcoord = TRANSFORM_TEX(v.shadowcoord, _ShadowTex);
+                
+                return o;
+            }
+
+            half4 frag(v2f i) : SV_Target
+            {
+                half4 color = tex2D(_MainTex, i.texcoord);
+                clip(color.a - _Threshold);
+                
+                if(_HasShadowTex > 0.5f)
+                {
+                    color *= tex2D(_ShadowTex, i.shadowcoord) / (1 - _Exposure);    
+                }
+                
+                return color;
+            }
+            ENDCG
+        }
+        
+        // Pass 2 ,transparent part
+        Pass
+        {
+            Tags{"Qeueue" = "Transparent"}
+            Blend SrcAlpha OneMinusSrcAlpha
+            ZWrite Off
+            
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 2.0
+            
+
+            #include "UnityCG.cginc"
+
+            struct appdata_t
+            {
+                float4 vertex : POSITION;
+                float2 texcoord : TEXCOORD0;
+                float2 shadowcoord : TEXCOORD1;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 texcoord : TEXCOORD0;
+                float2 shadowcoord : TEXCOORD1;
+                
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+            float _Threshold;
+            
+            v2f vert(appdata_t v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
+                
+                return o;
+            }
+
+            half4 frag(v2f i) : SV_Target
+            {
+                half4 color = tex2D(_MainTex, i.texcoord);
+                if(color.a >= _Threshold)
+                {
+                    discard;
+                }
+                return color;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/Pal3_Transparent.shader
+++ b/Assets/Shaders/Pal3_Transparent.shader
@@ -3,6 +3,7 @@ Shader "Pal3/Transparent"
     Properties
     {
         _MainTex ("Base (RGB) Trans (A)", 2D) = "white" {}
+        _TintColor ("Tint color", Color) = (1.0, 1.0, 1.0, 1.0)
         _Threshold ("Transparent Threshold", Range(0,1)) = 1.0
         
         _HasShadowTex ("Has Shadow Texture", Range(0,1)) = 0.0
@@ -56,6 +57,8 @@ Shader "Pal3/Transparent"
             sampler2D _ShadowTex;
             float4 _ShadowTex_ST;
             float _Exposure;
+
+            float4 _TintColor;
             
             v2f vert(appdata_t v)
             {
@@ -82,7 +85,7 @@ Shader "Pal3/Transparent"
                     color *= tex2D(_ShadowTex, i.shadowcoord) / (1 - _Exposure);
                     color.a = alpha;
                 }
-                
+                color *= _TintColor;
                 return color;
             }
             ENDCG

--- a/Assets/Shaders/Pal3_Transparent.shader
+++ b/Assets/Shaders/Pal3_Transparent.shader
@@ -74,7 +74,7 @@ Shader "Pal3/Transparent"
             half4 frag(v2f i) : SV_Target
             {
                 half4 color = tex2D(_MainTex, i.texcoord);
-                float alpha = color.a;
+                const float alpha = color.a;
                 if(color.a >= _Threshold)
                 {
                     discard;

--- a/Assets/Shaders/Pal3_Transparent.shader.meta
+++ b/Assets/Shaders/Pal3_Transparent.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 9a73f8d5b84814e63a97995e839fdabb
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/Pal3_Transparent_OpaquePart.shader
+++ b/Assets/Shaders/Pal3_Transparent_OpaquePart.shader
@@ -1,9 +1,10 @@
-Shader "Pal3/Transparent"
+Shader "Pal3/TransparentOpaquePart"
 {
     Properties
     {
         _MainTex ("Base (RGB) Trans (A)", 2D) = "white" {}
         _Threshold ("Transparent Threshold", Range(0,1)) = 1.0
+        
         
         _HasShadowTex ("Has Shadow Texture", Range(0,1)) = 0.0
         _ShadowTex ("Shadow Texture",2D) = "white" {}
@@ -13,14 +14,12 @@ Shader "Pal3/Transparent"
     {
         Lighting Off
         
-        Tags{"Queue" = "Transparent"}
-        
-        
-        // Pass 2 ,transparent part
+        Tags{"Qeueue" = "Geometry"}
+        // pass 1 , opaque part
         Pass
         {
-            Blend SrcAlpha OneMinusSrcAlpha
-            ZWrite Off
+            Blend Off
+            ZWrite On
             
             CGPROGRAM
             #pragma vertex vert
@@ -50,13 +49,12 @@ Shader "Pal3/Transparent"
             sampler2D _MainTex;
             float4 _MainTex_ST;
             float _Threshold;
-
             
             float _HasShadowTex;
             sampler2D _ShadowTex;
             float4 _ShadowTex_ST;
             float _Exposure;
-            
+
             v2f vert(appdata_t v)
             {
                 v2f o;
@@ -65,30 +63,25 @@ Shader "Pal3/Transparent"
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
                 o.shadowcoord = TRANSFORM_TEX(v.shadowcoord, _ShadowTex);
+                
                 return o;
             }
 
             half4 frag(v2f i) : SV_Target
             {
                 half4 color = tex2D(_MainTex, i.texcoord);
-                float alpha = color.a;
-                if(color.a >= _Threshold)
-                {
-                    discard;
-                }
-                
+                clip(color.a - _Threshold);
+
                 if(_HasShadowTex > 0.5f)
                 {
-                    color *= tex2D(_ShadowTex, i.shadowcoord) / (1 - _Exposure);
-                    color.a = alpha;
+                    color *= tex2D(_ShadowTex, i.shadowcoord) / (1 - _Exposure);    
                 }
-                
+                                
                 return color;
             }
             ENDCG
         }
         
+        
     }
-    
-    
 }

--- a/Assets/Shaders/Pal3_Transparent_OpaquePart.shader
+++ b/Assets/Shaders/Pal3_Transparent_OpaquePart.shader
@@ -3,6 +3,7 @@ Shader "Pal3/TransparentOpaquePart"
     Properties
     {
         _MainTex ("Base (RGB) Trans (A)", 2D) = "white" {}
+        _TintColor ("Tint color", Color) = (1.0, 1.0, 1.0, 1.0)
         _Threshold ("Transparent Threshold", Range(0,1)) = 1.0
         
         
@@ -55,6 +56,8 @@ Shader "Pal3/TransparentOpaquePart"
             float4 _ShadowTex_ST;
             float _Exposure;
 
+            float4 _TintColor;
+
             v2f vert(appdata_t v)
             {
                 v2f o;
@@ -76,7 +79,7 @@ Shader "Pal3/TransparentOpaquePart"
                 {
                     color *= tex2D(_ShadowTex, i.shadowcoord) / (1 - _Exposure);    
                 }
-                                
+                color *= _TintColor;
                 return color;
             }
             ENDCG

--- a/Assets/Shaders/Pal3_Transparent_OpaquePart.shader.meta
+++ b/Assets/Shaders/Pal3_Transparent_OpaquePart.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 784c49f60e0c64f6595ed503bd3a3a69
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
https://bytedance.feishu.cn/docx/I4SudJcDTovqHyx94f9claVPnQc


改动之后的效果可以看上面的文档。
对 Material 管理的部分 改动比较大。


主要的改动点，是整理了渲染顺序

现在的渲染顺序是：
先绘制所有物体 Opaque 部分 -> 绘制 Skybox -> 绘制所有物体 Transparent 的部分

原main分支的渲染顺序是靠 render queue 打补丁，会有badcase 
现在这样改之后，所有 transparent 的物体 应该不会有问题了。

代码待整理。先看效果，效果ok的话再看怎么整理一下代码，最后再看怎么合进去
