### PR TITLE
+water using indie material. apply water shadow texture on it

### DIFF
--- a/Assets/Scripts/Pal3/Renderer/IMaterialFactory.cs
+++ b/Assets/Scripts/Pal3/Renderer/IMaterialFactory.cs
@@ -32,5 +32,11 @@ namespace Pal3.Renderer
             Color tintColor,
             GameBoxBlendFlag blendFlag,
             float transparentThreshold);
+
+        
+        public Material CreateWaterMaterial(Texture2D mainTexture,
+            Texture2D normalTexture,
+            float alpha,
+            Color tintColor);
     }
 }

--- a/Assets/Scripts/Pal3/Renderer/IMaterialFactory.cs
+++ b/Assets/Scripts/Pal3/Renderer/IMaterialFactory.cs
@@ -33,10 +33,15 @@ namespace Pal3.Renderer
             GameBoxBlendFlag blendFlag,
             float transparentThreshold);
 
-        
+        /// <summary>
+        /// Create material for water surface
+        /// </summary>
+        /// <param name="mainTexture">Main texture</param>
+        /// <param name="shadowTexture">Shadow texture</param>
+        /// <param name="alpha">Opacity</param>
+        /// <returns>Material</returns>
         public Material CreateWaterMaterial(Texture2D mainTexture,
-            Texture2D normalTexture,
-            float alpha,
-            Color tintColor);
+            Texture2D shadowTexture,
+            float alpha);
     }
 }

--- a/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs
+++ b/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs
@@ -32,34 +32,31 @@ namespace Pal3.Renderer
         
         // Water material uniforms
         private static readonly int WaterMainTexPropId = Shader.PropertyToID("_MainTex");
-        private static readonly int Water2ndTexPropId = Shader.PropertyToID("_2ndTexture");
+        private static readonly int WaterShadowTexPropId = Shader.PropertyToID("_ShadowTex");
         private static readonly int WaterAlphaPropId = Shader.PropertyToID("_Alpha");
-        private static readonly int WaterHas2ndTexPropId = Shader.PropertyToID("_Has2ndTexture");
-        private static readonly int WaterTintColorPropId = Shader.PropertyToID("_TintColor");
-        
-        /* Water material */
+        private static readonly int WaterHasShadowTexPropId = Shader.PropertyToID("_HasShadowTex");
+
+        /// <inheritdoc/>
         public Material CreateWaterMaterial(Texture2D mainTexture, 
-            Texture2D the2ndTexture, 
-            float alpha,
-            Color tintColor)
+            Texture2D shadowTexture, 
+            float alpha)
         {
             var material = new Material(Shader.Find(WATER_SHADER_PATH));
             material.SetTexture(WaterMainTexPropId,mainTexture);
-            material.SetFloat(WaterAlphaPropId,alpha);
-            material.SetColor(WaterTintColorPropId,tintColor);
-            if (the2ndTexture != null)
+            material.SetFloat(WaterAlphaPropId, alpha);
+            if (shadowTexture != null)
             {
-                material.SetFloat(WaterHas2ndTexPropId,1.0f);
-                material.SetTexture(Water2ndTexPropId,the2ndTexture);
+                material.SetFloat(WaterHasShadowTexPropId, 1.0f);
+                material.SetTexture(WaterShadowTexPropId, shadowTexture);
             }
             else
             {
-                material.SetFloat(WaterHas2ndTexPropId,0.5f);
+                material.SetFloat(WaterHasShadowTexPropId, 0.5f);
             }
             return material;
         }
 
-        /* Sprtie material */
+        /// <inheritdoc/>
         public Material CreateSpriteMaterial(Texture2D texture)
         {
             var material = new Material(Shader.Find(SPRITE_SHADER_PATH));;
@@ -67,7 +64,7 @@ namespace Pal3.Renderer
             return material;
         }
 
-        /* Standard materials */
+        /// <inheritdoc/>
         public Material[] CreateStandardMaterials(
             Texture2D mainTexture,
             Texture2D shadowTexture,

--- a/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs
+++ b/Assets/Scripts/Pal3/Renderer/MaterialFactory.cs
@@ -15,6 +15,7 @@ namespace Pal3.Renderer
         private const string TRANSPARENT_SHADER_PATH = "Pal3/Transparent";
         private const string TRANSPARENT_OPAQUE_PART_SHADER_PATH = "Pal3/TransparentOpaquePart";
         private const string SPRITE_SHADER_PATH = "Pal3/Sprite";
+        private const string WATER_SHADER_PATH = "Pal3/Water";
 
         // Standard material uniforms 
         private static readonly int MainTexturePropertyId = Shader.PropertyToID("_MainTex");
@@ -29,6 +30,36 @@ namespace Pal3.Renderer
         // Sprite material uniforms
         private static readonly int SpriteMainTexPropertyId = Shader.PropertyToID("_MainTex");
         
+        // Water material uniforms
+        private static readonly int WaterMainTexPropId = Shader.PropertyToID("_MainTex");
+        private static readonly int Water2ndTexPropId = Shader.PropertyToID("_2ndTexture");
+        private static readonly int WaterAlphaPropId = Shader.PropertyToID("_Alpha");
+        private static readonly int WaterHas2ndTexPropId = Shader.PropertyToID("_Has2ndTexture");
+        private static readonly int WaterTintColorPropId = Shader.PropertyToID("_TintColor");
+        
+        /* Water material */
+        public Material CreateWaterMaterial(Texture2D mainTexture, 
+            Texture2D the2ndTexture, 
+            float alpha,
+            Color tintColor)
+        {
+            var material = new Material(Shader.Find(WATER_SHADER_PATH));
+            material.SetTexture(WaterMainTexPropId,mainTexture);
+            material.SetFloat(WaterAlphaPropId,alpha);
+            material.SetColor(WaterTintColorPropId,tintColor);
+            if (the2ndTexture != null)
+            {
+                material.SetFloat(WaterHas2ndTexPropId,1.0f);
+                material.SetTexture(Water2ndTexPropId,the2ndTexture);
+            }
+            else
+            {
+                material.SetFloat(WaterHas2ndTexPropId,0.5f);
+            }
+            return material;
+        }
+
+        /* Sprtie material */
         public Material CreateSpriteMaterial(Texture2D texture)
         {
             var material = new Material(Shader.Find(SPRITE_SHADER_PATH));;
@@ -36,6 +67,7 @@ namespace Pal3.Renderer
             return material;
         }
 
+        /* Standard materials */
         public Material[] CreateStandardMaterials(
             Texture2D mainTexture,
             Texture2D shadowTexture,

--- a/Assets/Scripts/Pal3/Renderer/PolyModelRenderer.cs
+++ b/Assets/Scripts/Pal3/Renderer/PolyModelRenderer.cs
@@ -29,7 +29,6 @@ namespace Pal3.Renderer
         
         private const float TRANSPARENT_THRESHOLD_WITHOUT_SHADOW = 1.0f;
         private const float TRANSPARENT_THRESHOLD_WITH_SHADOW = 0.9f;
-        private const float WATER_ALPHA = 0.5f;
 
         private ITextureResourceProvider _textureProvider;
         private IMaterialFactory _materialFactory;
@@ -125,18 +124,20 @@ namespace Pal3.Renderer
 
                 if (textures.Count == 1)
                 {
+                    Material[] materials;
+                    
                     var isWaterSurface = textures[0].name
                         .StartsWith(ANIMATED_WATER_TEXTURE_DEFAULT_NAME, StringComparison.OrdinalIgnoreCase);
-                    
-                    Material[] materials = null;
+
                     if (isWaterSurface)
                     {
                         materials = new Material[1];
+                        // get alpha from first pixel of the water texture
+                        float waterSurfaceOpacity = textures[0].texture.GetPixel(0, 0).a;
                         materials[0] = _materialFactory.CreateWaterMaterial(
                             textures[0].texture,
                             null,
-                            WATER_ALPHA,
-                            _tintColor);
+                            waterSurfaceOpacity);
                         StartWaterSurfaceAnimation(materials[0], textures[0].texture);
                     }
                     else
@@ -159,19 +160,20 @@ namespace Pal3.Renderer
                 }
                 else if (textures.Count >= 2)
                 {
+                    Material[] materials;
+                    
                     var isWaterSurface = textures[1].name
                         .StartsWith(ANIMATED_WATER_TEXTURE_DEFAULT_NAME, StringComparison.OrdinalIgnoreCase);
-
-
-                    Material[] materials = null;
+                    
                     if (isWaterSurface)
                     {
                         materials = new Material[1];
+                        // get alpha from first pixel of the water texture
+                        float waterSurfaceOpacity = textures[1].texture.GetPixel(0, 0).a;
                         materials[0] = _materialFactory.CreateWaterMaterial(
                             textures[1].texture,
                             textures[0].texture,
-                            WATER_ALPHA,
-                            _tintColor);
+                            waterSurfaceOpacity);
                         
                         StartWaterSurfaceAnimation(materials.Last(), textures[1].texture);
                     }
@@ -193,6 +195,7 @@ namespace Pal3.Renderer
                         ref materials,
                         false);
                 }
+                
                 meshObject.transform.SetParent(transform, false);
             }
         }

--- a/Assets/Scripts/Pal3/Renderer/PolyModelRenderer.cs
+++ b/Assets/Scripts/Pal3/Renderer/PolyModelRenderer.cs
@@ -197,7 +197,6 @@ namespace Pal3.Renderer
                 meshObject.transform.SetParent(transform, false);
             }
         }
-        
 
         private IEnumerator AnimateWaterTexture(Material material, Texture2D defaultTexture)
         {

--- a/Assets/Scripts/Pal3/Renderer/PolyModelRenderer.cs
+++ b/Assets/Scripts/Pal3/Renderer/PolyModelRenderer.cs
@@ -8,7 +8,6 @@ namespace Pal3.Renderer
     using System;
     using System.Collections;
     using System.Collections.Generic;
-    using System.Linq;
     using Core.DataLoader;
     using Core.DataReader.Pol;
     using Core.Renderer;
@@ -136,7 +135,7 @@ namespace Pal3.Renderer
                         float waterSurfaceOpacity = textures[0].texture.GetPixel(0, 0).a;
                         materials[0] = _materialFactory.CreateWaterMaterial(
                             textures[0].texture,
-                            null,
+                            shadowTexture: null,
                             waterSurfaceOpacity);
                         StartWaterSurfaceAnimation(materials[0], textures[0].texture);
                     }
@@ -144,7 +143,7 @@ namespace Pal3.Renderer
                     {
                         materials = _materialFactory.CreateStandardMaterials(
                             textures[0].texture,
-                            null,
+                            shadowTexture: null,
                             _tintColor,
                             blendFlag,
                             TRANSPARENT_THRESHOLD_WITHOUT_SHADOW);
@@ -174,8 +173,7 @@ namespace Pal3.Renderer
                             textures[1].texture,
                             textures[0].texture,
                             waterSurfaceOpacity);
-                        
-                        StartWaterSurfaceAnimation(materials.Last(), textures[1].texture);
+                        StartWaterSurfaceAnimation(materials[0], textures[1].texture);
                     }
                     else
                     {
@@ -195,7 +193,7 @@ namespace Pal3.Renderer
                         ref materials,
                         false);
                 }
-                
+
                 meshObject.transform.SetParent(transform, false);
             }
         }

--- a/Assets/Shaders/Pal3Dev.shader
+++ b/Assets/Shaders/Pal3Dev.shader
@@ -12,7 +12,7 @@ Shader "Pal3/Dev"
 
     SubShader 
     {
-        Tags { "Queue"="Transparent" "IgnoreProjector"="True" "RenderType"="Transparent" }
+        Tags { "Queue" = "Transparent" "IgnoreProjector" = "True" "RenderType" = "Transparent" }
         LOD 100
 
         ZWrite Off

--- a/Assets/Shaders/Pal3Opaque.shader
+++ b/Assets/Shaders/Pal3Opaque.shader
@@ -5,18 +5,18 @@ Shader "Pal3/Opaque"
         _MainTex ("Base (RGB) Trans (A)", 2D) = "white" {}
         _TintColor ("Tint color", Color) = (1.0, 1.0, 1.0, 1.0)
         
-        _HasShadowTex ("Has Shadow Texture", Range(0,1)) = 0.0
-        _ShadowTex ("Shadow Texture",2D) = "white" {}
-        _Exposure("Exposure Amount", Range(0.1,1.0)) = 0.4
+        _HasShadowTex ("Has Shadow Texture", Range(0, 1)) = 0.0
+        _ShadowTex ("Shadow Texture", 2D) = "white" {}
+        _Exposure("Exposure Amount", Range(0.1, 1.0)) = 0.4
     }
     SubShader
     {
         Lighting Off
-        Tags{"QUEUE" = "Geometry"}
+        Tags { "QUEUE" = "Geometry" }
         
         Pass
         {
-            Tags{"Qeueue" = "Geometry"}
+            Tags{ "Qeueue" = "Geometry" }
             Blend Off
             ZWrite On
             
@@ -24,7 +24,6 @@ Shader "Pal3/Opaque"
             #pragma vertex vert
             #pragma fragment frag
             #pragma target 2.0
-            
 
             #include "UnityCG.cginc"
 

--- a/Assets/Shaders/Pal3Transparent.shader
+++ b/Assets/Shaders/Pal3Transparent.shader
@@ -4,23 +4,23 @@ Shader "Pal3/Transparent"
     {
         _MainTex ("Base (RGB) Trans (A)", 2D) = "white" {}
         _TintColor ("Tint color", Color) = (1.0, 1.0, 1.0, 1.0)
-        _Threshold ("Transparent Threshold", Range(0,1)) = 1.0
+        _Threshold ("Transparent Threshold", Range(0, 1)) = 1.0
         
-        _HasShadowTex ("Has Shadow Texture", Range(0,1)) = 0.0
-        _ShadowTex ("Shadow Texture",2D) = "white" {}
-        _Exposure("Exposure Amount", Range(0.1,1.0)) = 0.4
-        
-        [Enum(UnityEngine.Rendering.BlendMode)]
-        _BlendSrcFactor("Source Blend Factor",int) = 5    // BlendMode.SrcAlpha as Default
+        _HasShadowTex ("Has Shadow Texture", Range(0, 1)) = 0.0
+        _ShadowTex ("Shadow Texture", 2D) = "white" {}
+        _Exposure("Exposure Amount", Range(0.1, 1.0)) = 0.4
         
         [Enum(UnityEngine.Rendering.BlendMode)]
-        _BlendDstFactor("Dest Blend Factor",int) = 10     // BlendMode.OneMinusSrcAlpha as Default
+        _BlendSrcFactor("Source Blend Factor", int) = 5    // BlendMode.SrcAlpha as Default
+        
+        [Enum(UnityEngine.Rendering.BlendMode)]
+        _BlendDstFactor("Dest Blend Factor", int) = 10     // BlendMode.OneMinusSrcAlpha as Default
     }
     SubShader
     {
         Lighting Off
         
-        Tags{"Queue" = "Transparent"}
+        Tags { "Queue" = "Transparent" }
         
         // Pass 2 ,transparent part
         Pass

--- a/Assets/Shaders/Pal3TransparentOpaquePart.shader
+++ b/Assets/Shaders/Pal3TransparentOpaquePart.shader
@@ -4,17 +4,17 @@ Shader "Pal3/TransparentOpaquePart"
     {
         _MainTex ("Base (RGB) Trans (A)", 2D) = "white" {}
         _TintColor ("Tint color", Color) = (1.0, 1.0, 1.0, 1.0)
-        _Threshold ("Transparent Threshold", Range(0,1)) = 1.0
+        _Threshold ("Transparent Threshold", Range(0, 1)) = 1.0
         
-        _HasShadowTex ("Has Shadow Texture", Range(0,1)) = 0.0
-        _ShadowTex ("Shadow Texture",2D) = "white" {}
-        _Exposure("Exposure Amount", Range(0.1,1.0)) = 0.4
+        _HasShadowTex ("Has Shadow Texture", Range(0, 1)) = 0.0
+        _ShadowTex ("Shadow Texture", 2D) = "white" {}
+        _Exposure("Exposure Amount", Range(0.1, 1.0)) = 0.4
     }
     SubShader
     {
         Lighting Off
         
-        Tags{"Qeueue" = "Geometry"}
+        Tags { "Qeueue" = "Geometry" }
         
         // pass 1 , opaque part
         Pass
@@ -26,7 +26,6 @@ Shader "Pal3/TransparentOpaquePart"
             #pragma vertex vert
             #pragma fragment frag
             #pragma target 2.0
-            
 
             #include "UnityCG.cginc"
 

--- a/Assets/Shaders/Pal3Water.shader
+++ b/Assets/Shaders/Pal3Water.shader
@@ -8,12 +8,11 @@ Shader "Pal3/Water"
         // alpha value
         _Alpha ("Alpha",Range(0, 1)) = 0.5
         
+        _Exposure("Exposure Amount", Range(0.1, 1.0)) = 0.3
+        
         // pre baked shadow texture
         _ShadowTex ("Shadow texture", 2D) = "white" {}
         _HasShadowTex ("Has Shadow Texture", Range(0, 1)) = 0.0
-        
-        // tint color
-        _TintColor ("Tint color", Color) = (1.0, 1.0, 1.0, 1.0)
         
         [Enum(UnityEngine.Rendering.BlendMode)]
         _BlendSrcFactor("Source Blend Factor", int) = 5    // BlendMode.SrcAlpha as Default
@@ -59,9 +58,8 @@ Shader "Pal3/Water"
             float4 _MainTex_ST;
 
             float _Alpha;
-            
-            float4 _TintColor;
-            
+            float _Exposure;
+
             float _HasShadowTex;
             sampler2D _ShadowTex;
             float4 _ShadowTex_ST;
@@ -82,7 +80,7 @@ Shader "Pal3/Water"
             {
                 const half4 color = tex2D(_MainTex, i.texcoord);
                 const half4 colorShadow = tex2D(_ShadowTex, i.texcoord2);
-                half4 mixedColor = color * colorShadow * _TintColor;
+                half4 mixedColor = color * colorShadow / (1 - _Exposure);
                 mixedColor.a = _Alpha; // use global alpha
                 return mixedColor;
             }

--- a/Assets/Shaders/Pal3Water.shader
+++ b/Assets/Shaders/Pal3Water.shader
@@ -5,27 +5,27 @@ Shader "Pal3/Water"
         // main texture
         _MainTex ("Main texture", 2D) = "white" {}
         
-        // alpha value. useless
-        _Alpha ("Alpha",Range(0,1)) = 0.5
+        // alpha value
+        _Alpha ("Alpha",Range(0, 1)) = 0.5
         
-        // 2nd texture. seems like pre baked shadow
-        _2ndTexture ("2nd texture", 2D) = "white" {}
-        _Has2ndTexture ("Has 2nd Texture", Range(0,1)) = 0.0
+        // pre baked shadow texture
+        _ShadowTex ("Shadow texture", 2D) = "white" {}
+        _HasShadowTex ("Has Shadow Texture", Range(0, 1)) = 0.0
         
-        // tint color for handle night env
+        // tint color
         _TintColor ("Tint color", Color) = (1.0, 1.0, 1.0, 1.0)
         
         [Enum(UnityEngine.Rendering.BlendMode)]
-        _BlendSrcFactor("Source Blend Factor",int) = 5    // BlendMode.SrcAlpha as Default
+        _BlendSrcFactor("Source Blend Factor", int) = 5    // BlendMode.SrcAlpha as Default
         
         [Enum(UnityEngine.Rendering.BlendMode)]
-        _BlendDstFactor("Dest Blend Factor",int) = 1     // BlendMode.One as Default
+        _BlendDstFactor("Dest Blend Factor", int) = 10     // BlendMode.OneMinusSrcAlpha as Default
     }
     
     SubShader
     {
         Lighting Off
-        Tags{"QUEUE" = "Transparent"}
+        Tags { "QUEUE" = "Transparent" }
         
         Pass
         {
@@ -52,11 +52,8 @@ Shader "Pal3/Water"
                 float4 vertex : SV_POSITION;
                 float2 texcoord : TEXCOORD0;
                 float2 texcoord2 : TEXCOORD1;
-                
                 UNITY_VERTEX_OUTPUT_STEREO
             };
-
-            
             
             sampler2D _MainTex;
             float4 _MainTex_ST;
@@ -65,9 +62,9 @@ Shader "Pal3/Water"
             
             float4 _TintColor;
             
-            float _Has2ndTexture;
-            sampler2D _2ndTexture;
-            float4 _2ndTexture_ST;
+            float _HasShadowTex;
+            sampler2D _ShadowTex;
+            float4 _ShadowTex_ST;
             
             v2f vert(appdata_t v)
             {
@@ -76,7 +73,7 @@ Shader "Pal3/Water"
                 UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
                 o.vertex = UnityObjectToClipPos(v.vertex);
                 o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
-                o.texcoord2 = TRANSFORM_TEX(v.texcoord2, _2ndTexture);
+                o.texcoord2 = TRANSFORM_TEX(v.texcoord2, _ShadowTex);
                 
                 return o;
             }
@@ -84,8 +81,10 @@ Shader "Pal3/Water"
             half4 frag(v2f i) : SV_Target
             {
                 const half4 color = tex2D(_MainTex, i.texcoord);
-                const half4 colorShadow = tex2D(_2ndTexture,i.texcoord2);
-                return color * colorShadow * _TintColor;
+                const half4 colorShadow = tex2D(_ShadowTex, i.texcoord2);
+                half4 mixedColor = color * colorShadow * _TintColor;
+                mixedColor.a = _Alpha; // use global alpha
+                return mixedColor;
             }
             ENDCG
         }

--- a/Assets/Shaders/Pal3Water.shader
+++ b/Assets/Shaders/Pal3Water.shader
@@ -1,0 +1,93 @@
+Shader "Pal3/Water"
+{
+    Properties
+    {
+        // main texture
+        _MainTex ("Main texture", 2D) = "white" {}
+        
+        // alpha value. useless
+        _Alpha ("Alpha",Range(0,1)) = 0.5
+        
+        // 2nd texture. seems like pre baked shadow
+        _2ndTexture ("2nd texture", 2D) = "white" {}
+        _Has2ndTexture ("Has 2nd Texture", Range(0,1)) = 0.0
+        
+        // tint color for handle night env
+        _TintColor ("Tint color", Color) = (1.0, 1.0, 1.0, 1.0)
+        
+        [Enum(UnityEngine.Rendering.BlendMode)]
+        _BlendSrcFactor("Source Blend Factor",int) = 5    // BlendMode.SrcAlpha as Default
+        
+        [Enum(UnityEngine.Rendering.BlendMode)]
+        _BlendDstFactor("Dest Blend Factor",int) = 10     // BlendMode.OneMinusSrcAlpha as Default
+        
+    }
+    SubShader
+    {
+        Lighting Off
+        Tags{"QUEUE" = "Transparent"}
+        
+        Pass
+        {
+            Blend [_BlendSrcFactor] [_BlendDstFactor]
+            ZWrite Off
+            
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #pragma target 2.0
+            
+            #include "UnityCG.cginc"
+
+            struct appdata_t
+            {
+                float4 vertex : POSITION;
+                float2 texcoord : TEXCOORD0;
+                float2 texcoord2 : TEXCOORD1;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 texcoord : TEXCOORD0;
+                float2 texcoord2 : TEXCOORD1;
+                
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            
+            
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+
+            float _Alpha;
+            
+            float4 _TintColor;
+            
+            float _Has2ndTexture;
+            sampler2D _2ndTexture;
+            float4 _2ndTexture_ST;
+            
+            v2f vert(appdata_t v)
+            {
+                v2f o;
+                UNITY_SETUP_INSTANCE_ID(v);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
+                o.texcoord2 = TRANSFORM_TEX(v.texcoord2, _2ndTexture);
+                
+                return o;
+            }
+
+            half4 frag(v2f i) : SV_Target
+            {
+                const half4 color = tex2D(_MainTex, i.texcoord);
+                const half4 colorShadow = tex2D(_2ndTexture,i.texcoord2);
+                return color * colorShadow * _TintColor;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Shaders/Pal3Water.shader
+++ b/Assets/Shaders/Pal3Water.shader
@@ -19,9 +19,9 @@ Shader "Pal3/Water"
         _BlendSrcFactor("Source Blend Factor",int) = 5    // BlendMode.SrcAlpha as Default
         
         [Enum(UnityEngine.Rendering.BlendMode)]
-        _BlendDstFactor("Dest Blend Factor",int) = 10     // BlendMode.OneMinusSrcAlpha as Default
-        
+        _BlendDstFactor("Dest Blend Factor",int) = 1     // BlendMode.One as Default
     }
+    
     SubShader
     {
         Lighting Off

--- a/Assets/Shaders/Pal3Water.shader.meta
+++ b/Assets/Shaders/Pal3Water.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 54296b5ef906d4d219289838c47b2f01
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
单独处理 水的material . MaterialFactory 新增 CreateWaterMaterial() 的实现

水的两个贴图含义是：
mainTexture 表示水的 主纹理，用于做 uv动画表示水流动；
第2个 texture ，需要和水的颜色做乘法。
用于表示 水和水岸边上的物体， 事先烘焙好的影子的效果   

水的第2个 texture ：

如果不预乘，水和岸交界处无阴影效果：
![image](https://user-images.githubusercontent.com/8259193/196037125-14bc1055-aa1d-4086-8700-68125205e063.png)

预乘之后，水面和岸边交界处，有阴影效果：
![image](https://user-images.githubusercontent.com/8259193/196037076-1614a62b-19dd-4b71-9b21-ea962cdb4a8b.png)

预乘，加修改 BlendMode 为 srcAlpha, One 之后，甚至还能有点“倒影”的效果
![image](https://user-images.githubusercontent.com/8259193/196037270-8ad98c2e-88a4-4cd5-be70-79e77a2e5e38.png)

下面链接里，有和原游戏的对比
https://o2oh6846tj.feishu.cn/wiki/wikcnyfUyYcLMhafuhJHobPVMhg