### PR TITLE
+add Test Trail Effect to Main Character

### DIFF
--- a/Assets/Resources/Effects.meta
+++ b/Assets/Resources/Effects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b8ede490264a144e79dfee035f72948a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Effects/Trail.prefab
+++ b/Assets/Resources/Effects/Trail.prefab
@@ -1,0 +1,151 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4766600888214445738
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6048748682631107677}
+  - component: {fileID: 9066380243945606481}
+  - component: {fileID: 4681111045271042056}
+  m_Layer: 0
+  m_Name: Trail
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6048748682631107677
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4766600888214445738}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -3.8}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!120 &9066380243945606481
+LineRenderer:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4766600888214445738}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 84847fcdaa22a48bbb8b56d5f28c259b, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Positions:
+  - {x: 0, y: 0, z: 0}
+  - {x: 2, y: 0, z: 0}
+  m_Parameters:
+    serializedVersion: 3
+    widthMultiplier: 1
+    widthCurve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    colorGradient:
+      serializedVersion: 2
+      key0: {r: 1, g: 1, b: 1, a: 1}
+      key1: {r: 1, g: 1, b: 1, a: 1}
+      key2: {r: 0, g: 0, b: 0, a: 0}
+      key3: {r: 0, g: 0, b: 0, a: 0}
+      key4: {r: 0, g: 0, b: 0, a: 0}
+      key5: {r: 0, g: 0, b: 0, a: 0}
+      key6: {r: 0, g: 0, b: 0, a: 0}
+      key7: {r: 0, g: 0, b: 0, a: 0}
+      ctime0: 0
+      ctime1: 65535
+      ctime2: 0
+      ctime3: 0
+      ctime4: 0
+      ctime5: 0
+      ctime6: 0
+      ctime7: 0
+      atime0: 0
+      atime1: 65535
+      atime2: 0
+      atime3: 0
+      atime4: 0
+      atime5: 0
+      atime6: 0
+      atime7: 0
+      m_Mode: 0
+      m_ColorSpace: -1
+      m_NumColorKeys: 2
+      m_NumAlphaKeys: 2
+    numCornerVertices: 0
+    numCapVertices: 0
+    alignment: 0
+    textureMode: 0
+    textureScale: {x: 1, y: 1}
+    shadowBias: 0.5
+    generateLightingData: 0
+  m_MaskInteraction: 0
+  m_UseWorldSpace: 1
+  m_Loop: 0
+  m_ApplyActiveColorSpace: 1
+--- !u!114 &4681111045271042056
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4766600888214445738}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 234610e62630b4a1399ec9bd193aa685, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Resources/Effects/Trail.prefab.meta
+++ b/Assets/Resources/Effects/Trail.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b3d816dbe6c5f4efeb78bda73e88fd64
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Effects/Trail.shader
+++ b/Assets/Resources/Effects/Trail.shader
@@ -1,0 +1,56 @@
+Shader "Pal3/Effect/Trail"
+{
+    Properties
+    {
+        _MainTex ("Texture", 2D) = "white" {}
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" }
+        LOD 100
+        Cull Back
+
+        Pass
+        {
+            CGPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            
+
+            #include "UnityCG.cginc"
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                float4 vertex : SV_POSITION;
+            };
+
+            sampler2D _MainTex;
+            float4 _MainTex_ST;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = TRANSFORM_TEX(v.uv, _MainTex);
+                
+                return o;
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                // sample the texture
+                // fixed4 col = tex2D(_MainTex, i.uv);
+                return fixed4(i.uv,0.0,1.0);
+                //return col;
+            }
+            ENDCG
+        }
+    }
+}

--- a/Assets/Resources/Effects/Trail.shader.meta
+++ b/Assets/Resources/Effects/Trail.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 16fc2355979b9481b90f5c64e62bcb49
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Effects/TrailMaterial.mat
+++ b/Assets/Resources/Effects/TrailMaterial.mat
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: TrailMaterial
+  m_Shader: {fileID: 4800000, guid: 16fc2355979b9481b90f5c64e62bcb49, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Resources/Effects/TrailMaterial.mat.meta
+++ b/Assets/Resources/Effects/TrailMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 84847fcdaa22a48bbb8b56d5f28c259b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pal3/Actor/ActorFactory.cs
+++ b/Assets/Scripts/Pal3/Actor/ActorFactory.cs
@@ -3,6 +3,8 @@
 //  See LICENSE file in the project root for license information.
 // ---------------------------------------------------------------------------------------------
 
+using Pal3.Effect;
+
 namespace Pal3.Actor
 {
     using System;
@@ -87,6 +89,12 @@ namespace Pal3.Actor
                     break;
                 case PlayerActorId.LongKui:
                     actorGameObject.AddComponent<LongKuiController>().Init(actor, actionController);
+                    break;
+                case PlayerActorId.JingTian:
+                    var trailGameObject = resourceProvider.GetEffectFactory().CreateTrail();
+                    trailGameObject.transform.SetParent(actorGameObject.transform);
+                    var trailController = trailGameObject.GetComponent<TrailController>();
+                    trailController.SetPointLifeSpan(0.5f);
                     break;
             }
             #elif PAL3A

--- a/Assets/Scripts/Pal3/Data/GameResourceProvider.cs
+++ b/Assets/Scripts/Pal3/Data/GameResourceProvider.cs
@@ -3,6 +3,8 @@
 //  See LICENSE file in the project root for license information.
 // ---------------------------------------------------------------------------------------------
 
+using Pal3.Effect;
+
 namespace Pal3.Data
 {
     using System;
@@ -47,6 +49,8 @@ namespace Pal3.Data
         private readonly ITextureLoaderFactory _textureLoaderFactory;
         private readonly IMaterialFactory _unlitMaterialFactory;
         private readonly IMaterialFactory _litMaterialFactory;
+        private readonly CommonEffectFactory _commonEffectFactory;
+        
         private readonly GameSettings _gameSettings;
 
         private readonly GdbFile _gameDatabase;
@@ -70,12 +74,14 @@ namespace Pal3.Data
             ITextureLoaderFactory textureLoaderFactory,
             IMaterialFactory unlitMaterialFactory,
             IMaterialFactory litMaterialFactory,
+            CommonEffectFactory effectFactory,
             GameSettings gameSettings)
         {
             _fileSystem = Requires.IsNotNull(fileSystem, nameof(fileSystem));
             _textureLoaderFactory = Requires.IsNotNull(textureLoaderFactory, nameof(textureLoaderFactory));
             _unlitMaterialFactory = Requires.IsNotNull(unlitMaterialFactory, nameof(unlitMaterialFactory));
             _litMaterialFactory = litMaterialFactory; // Lit materials are not required
+            _commonEffectFactory = effectFactory;
             _gameSettings = Requires.IsNotNull(gameSettings, nameof(gameSettings));
 
             _codepage = _gameSettings.Language == Language.SimplifiedChinese ? 936 : 950;
@@ -136,6 +142,11 @@ namespace Pal3.Data
             return !_gameSettings.IsOpenSourceVersion && _gameSettings.IsRealtimeLightingAndShadowsEnabled ?
                 _litMaterialFactory :
                 _unlitMaterialFactory;
+        }
+
+        public CommonEffectFactory GetEffectFactory()
+        {
+            return _commonEffectFactory;
         }
 
         public ITextureResourceProvider CreateTextureResourceProvider(string relativeDirectoryPath, bool useCache = true)

--- a/Assets/Scripts/Pal3/Effect/Common.meta
+++ b/Assets/Scripts/Pal3/Effect/Common.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c5571bfd2e0e4637a79c87331d8323c6
+timeCreated: 1692808030

--- a/Assets/Scripts/Pal3/Effect/Common/CommonEffectFactory.cs
+++ b/Assets/Scripts/Pal3/Effect/Common/CommonEffectFactory.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Pal3.Effect
+{
+    public class CommonEffectFactory
+    {
+        private Dictionary<string, GameObject> _cache = new Dictionary<string, GameObject>();
+        
+        public GameObject CreateTrail()
+        {
+            GameObject prefab = GetFromCache("Effects/Trail");
+            return GameObject.Instantiate(prefab);
+        }
+        
+        private GameObject GetFromCache(string path)
+        {
+            if (_cache.ContainsKey(path))
+            {
+                return _cache[path];
+            }
+            GameObject prefab = Resources.Load<GameObject>("Effects/Trail");
+            _cache.Add(path,prefab);
+            return prefab;
+        }
+    }
+
+}
+

--- a/Assets/Scripts/Pal3/Effect/Common/CommonEffectFactory.cs.meta
+++ b/Assets/Scripts/Pal3/Effect/Common/CommonEffectFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7f911b63971546a5bd8ce3af70215f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pal3/Effect/Common/TrailController.cs
+++ b/Assets/Scripts/Pal3/Effect/Common/TrailController.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using TreeEditor;
+using UnityEditor.UIElements;
+using UnityEngine;
+
+namespace Pal3.Effect
+{
+    public class TrailController : MonoBehaviour
+    {
+        private LineRenderer _lineRenderer = null;
+        private int _maxPoint = 50;
+        private Vector3 _posOffset = new Vector3(0, 3, 0);
+        private float _defaultLifeSpan = 3.0f;
+        class TrailPoint
+        {
+            public Vector3 point;
+            public float lifeSpan;
+        }
+        
+        private List<TrailPoint> _allPoints = new List<TrailPoint>();
+        private void Awake()
+        {
+            _lineRenderer = GetComponent<LineRenderer>();
+            
+        }
+
+        public void SetPointLifeSpan(float lifeSpan)
+        {
+            _defaultLifeSpan = lifeSpan;
+        }
+
+        void Update()
+        {
+            gameObject.transform.localPosition = _posOffset;
+            
+            ReduceLifeSpan(Time.deltaTime);
+            
+            var curPos = gameObject.transform.position;
+
+            bool bShouldAddPoint = false;
+            if (_allPoints.Count == 0)
+            {
+                bShouldAddPoint = true;
+            }
+            else if (!CheckNear(_allPoints[_allPoints.Count - 1].point, curPos))
+            {
+                bShouldAddPoint = true;
+            }
+            
+            if(bShouldAddPoint)
+            {
+                AddPoint(curPos);
+            }
+            RefreshLineRenderer();
+        }
+
+        private void ReduceLifeSpan(float deltaTime)
+        {
+            if (_allPoints.Count == 0)
+                return;
+            
+            foreach (var trailPoint in _allPoints)
+            {
+                trailPoint.lifeSpan -= deltaTime;
+            }
+            if (_allPoints[0].lifeSpan <= 0f)
+            {
+                _allPoints.RemoveAt(0);
+            }
+        }
+
+        private bool CheckNear(Vector3 p1,Vector3 p2)
+        {
+            return Vector3.Distance(p1, p2) <= Mathf.Epsilon;
+        }
+
+        private void AddPoint(Vector3 point)
+        {
+            var trailPoint = new TrailPoint();
+            trailPoint.point = point;
+            trailPoint.lifeSpan = _defaultLifeSpan;
+            _allPoints.Add(trailPoint);
+        }
+
+        private void RefreshLineRenderer()
+        {
+            Vector3[] allPos = new Vector3[_allPoints.Count];
+            for(int i = 0;i < _allPoints.Count;i++)
+            {
+                allPos[i] = _allPoints[i].point;
+            }
+            
+            _lineRenderer.positionCount = _allPoints.Count;
+            _lineRenderer.SetPositions(allPos);
+        }
+    }
+
+}
+

--- a/Assets/Scripts/Pal3/Effect/Common/TrailController.cs.meta
+++ b/Assets/Scripts/Pal3/Effect/Common/TrailController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 234610e62630b4a1399ec9bd193aa685
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pal3/GameResourceInitializer.cs
+++ b/Assets/Scripts/Pal3/GameResourceInitializer.cs
@@ -3,6 +3,8 @@
 //  See LICENSE file in the project root for license information.
 // ---------------------------------------------------------------------------------------------
 
+using Pal3.Effect;
+
 namespace Pal3
 {
     using System;
@@ -192,12 +194,16 @@ namespace Pal3
             {
                 unlitMaterialFactory.AllocateMaterialPool();
             }
+            
+            // Common Effect Factory
+            CommonEffectFactory effectFactory = new CommonEffectFactory();
 
             // Init Game resource provider
             var resourceProvider = new GameResourceProvider(cpkFileSystem,
                 new TextureLoaderFactory(),
                 unlitMaterialFactory,
                 litMaterialFactory,
+                effectFactory,
                 gameSettings);
             ServiceLocator.Instance.Register(resourceProvider);
 


### PR DESCRIPTION
![image](https://github.com/0x7c13/Pal3.Unity/assets/8259193/be36de6d-c00d-431a-80bf-36664aa000cd)
测试代码在 ActorFactory 的 93行；

新增了 Resource/Effect/ 目录，用来做 Effect 相关的 Prefab;
Resources/Effect/Trail.prefab 用来做 拖尾表现；
将来拖尾类型多了可以考虑这里多创建 prefab ，或者代码里动态创建。比如trail 的宽度可以再prefab 里调整会比较方便；
Resources/Effect 目录下的 prefab 用 Effect/Common/CommonEffectFactory.cs 收口加载 ；

核心的代码是 在 Effect/Common/TrailController.cs。
这里有几个核心参数：
1. _posOffset，用来表示 拖拽点 在原模型上的偏移；
2. _defaultLifeSpan 表示一个点存活时间多久
3. TraiController.cs 的 Update里面做了一些逻辑，用来让 点 不会无休止增加、点可以按时间销毁 
![image](https://github.com/0x7c13/Pal3.Unity/assets/8259193/0c002ab4-543d-40c9-ba91-6ba44d8a395f)

