### PR TITLE
Fbx exporter

### DIFF
--- a/Assets/Resources/Prefabs/Game Resource Viewer.prefab
+++ b/Assets/Resources/Prefabs/Game Resource Viewer.prefab
@@ -1019,6 +1019,148 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &522241034777681689
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3335857219313203615}
+  - component: {fileID: 9163930543252679725}
+  - component: {fileID: 4364513223528252075}
+  - component: {fileID: 631309010157143490}
+  - component: {fileID: 2244227741830881448}
+  m_Layer: 5
+  m_Name: ExportFbxButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3335857219313203615
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 522241034777681689}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8843398612776157872}
+  m_Father: {fileID: 7962283254459483698}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &9163930543252679725
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 522241034777681689}
+  m_CullTransparentMesh: 1
+--- !u!114 &4364513223528252075
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 522241034777681689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.36862746}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &631309010157143490
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 522241034777681689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 0, g: 0, b: 0, a: 0.64705884}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.6509434, g: 0.6509434, b: 0.6509434, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4364513223528252075}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &2244227741830881448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 522241034777681689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 70
+  m_MinHeight: -1
+  m_PreferredWidth: 90
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &557359860440283034
 GameObject:
   m_ObjectHideFlags: 0
@@ -1330,6 +1472,62 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1545107152497282662}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 20
+  m_MinHeight: -1
+  m_PreferredWidth: 20
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &1553057517533817070
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2403922291161562272}
+  - component: {fileID: 2390231654117789397}
+  m_Layer: 5
+  m_Name: Spacer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2403922291161562272
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1553057517533817070}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7962283254459483698}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2390231654117789397
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1553057517533817070}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
@@ -2341,6 +2539,140 @@ MonoBehaviour:
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &4347472834413528159
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8843398612776157872}
+  - component: {fileID: 1147022933062657305}
+  - component: {fileID: 6952554053714890926}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8843398612776157872
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4347472834413528159}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3335857219313203615}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1147022933062657305
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4347472834413528159}
+  m_CullTransparentMesh: 1
+--- !u!114 &6952554053714890926
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4347472834413528159}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Fbx
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 9e1d886e63529bb4ca3c95ece3e3189c, type: 2}
+  m_sharedMaterial: {fileID: 2847917559404452115, guid: 9e1d886e63529bb4ca3c95ece3e3189c, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 18
+  m_fontSizeBase: 18
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &4644526841211930874
 GameObject:
   m_ObjectHideFlags: 0
@@ -2454,6 +2786,7 @@ MonoBehaviour:
   randomMp3Button: {fileID: 4620712651305624973}
   randomMovButton: {fileID: 5427468017432232242}
   extractAllCpkFilesButton: {fileID: 560139499795418513}
+  exportFbxButton: {fileID: 631309010157143490}
   audioSource: {fileID: 2142775988}
   fpsCounter: {fileID: 5259780322708739529}
 --- !u!82 &4596748654320625574
@@ -2805,6 +3138,8 @@ RectTransform:
   - {fileID: 4368649423705725990}
   - {fileID: 4382597048068323552}
   - {fileID: 1132578971298683386}
+  - {fileID: 2403922291161562272}
+  - {fileID: 3335857219313203615}
   - {fileID: 746519510}
   m_Father: {fileID: 1713758292}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/ResourceViewer.unity
+++ b/Assets/Scenes/ResourceViewer.unity
@@ -38,7 +38,6 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -104,7 +103,7 @@ NavMeshSettings:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
-    serializedVersion: 2
+    serializedVersion: 3
     agentTypeID: 0
     agentRadius: 0.5
     agentHeight: 2
@@ -117,7 +116,7 @@ NavMeshSettings:
     cellSize: 0.16666667
     manualTileSize: 0
     tileSize: 256
-    accuratePlacement: 0
+    buildHeightMesh: 0
     maxJobWorkers: 0
     preserveTilesOutsideBounds: 0
     debug:
@@ -153,6 +152,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
   m_MoveRepeatDelay: 0.5
   m_MoveRepeatRate: 0.1
   m_XRTrackingOrigin: {fileID: 0}
@@ -169,6 +169,7 @@ MonoBehaviour:
   m_TrackedDeviceOrientationAction: {fileID: 7970375526676320489, guid: ca9f5fa95ffab41fb9a615ab714db018, type: 3}
   m_DeselectOnBackgroundClick: 1
   m_PointerBehavior: 0
+  m_CursorLockBehavior: 0
 --- !u!114 &806768033
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -191,19 +192,20 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 806768031}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &2755888771526933938
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 2675203688159455099, guid: 3ef1d32c83f86744286e2067bc5f73e4, type: 3}
@@ -475,12 +477,16 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3ef1d32c83f86744286e2067bc5f73e4, type: 3}
 --- !u!1001 &6005496283450936117
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 6005496284174148228, guid: 23121fd589eec48458b9201ba9cfc3f7, type: 3}
@@ -536,4 +542,14 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 23121fd589eec48458b9201ba9cfc3f7, type: 3}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 6005496283450936117}
+  - {fileID: 2755888771526933938}
+  - {fileID: 806768034}

--- a/Assets/Scripts/Pal3.ResourceViewer/FBXExporter.cs
+++ b/Assets/Scripts/Pal3.ResourceViewer/FBXExporter.cs
@@ -96,9 +96,12 @@ namespace Pal3.ResourceViewer
             {
                 int vertIdx = mv3Mesh.GameBoxTriangles[faceIdx * 3];
                 destMesh.BeginPolygon();
+                // destMesh.AddPolygon(vertIdx);
+                // destMesh.AddPolygon(vertIdx + 1);
+                // destMesh.AddPolygon(vertIdx + 2);
                 destMesh.AddPolygon(vertIdx);
-                destMesh.AddPolygon(vertIdx + 1);
                 destMesh.AddPolygon(vertIdx + 2);
+                destMesh.AddPolygon(vertIdx + 1);
                 destMesh.EndPolygon();
             }
         }

--- a/Assets/Scripts/Pal3.ResourceViewer/FBXExporter.cs
+++ b/Assets/Scripts/Pal3.ResourceViewer/FBXExporter.cs
@@ -19,9 +19,7 @@ namespace Pal3.ResourceViewer
                 Mv3Mesh mv3Mesh = mv3File.Meshes[meshIdx];
                 int frameCnt = mv3Mesh.KeyFrames.Length;
                 
-                // for (int frameIdx = 0;frameIdx < frameCnt;frameIdx++)
-                // {
-
+                
                 int frameIdx = 0;
                 FbxNode meshNode = FbxNode.Create(fbxScene,"mesh_at_frame_" + frameIdx);
                 FbxMesh fbxMesh = FbxMesh.Create(fbxScene,"MyMeshGeometry");
@@ -37,21 +35,17 @@ namespace Pal3.ResourceViewer
                 FbxBlendShape blendShape = FbxBlendShape.Create(fbxManager,"bs1");
                 for (frameIdx = 1;frameIdx < frameCnt;frameIdx++)
                 {
-                    FbxBlendShapeChannel shapeKeyChannel1 = FbxBlendShapeChannel.Create(fbxManager, "shapeKeyChannel_" + frameIdx);
-                    FbxShape shape1 = FbxShape.Create(fbxManager,"shape_" + frameIdx);
-                    shape1.InitControlPoints(vertexCount);
+                    FbxBlendShapeChannel channel = FbxBlendShapeChannel.Create(fbxManager, "shapeKeyChannel_" + frameIdx);
+                    FbxShape shape = FbxShape.Create(fbxManager,"frame_" + frameIdx);
+                    shape.InitControlPoints(vertexCount);
                     for (int vertIdx = 0; vertIdx < vertexCount; vertIdx++)
                     {
-                        // var pt = new FbxVector4(0, 0, 0, 1);
-                        // shape1.SetControlPointAt(pt, vertIdx);
-                        
                         GameBoxVector3 pt = mv3Mesh.KeyFrames[frameIdx].GameBoxVertices[vertIdx];
                         Vector3 unityAttPos = pt.ToUnityPosition();
-                        shape1.SetControlPointAt(new FbxVector4(unityAttPos.x,unityAttPos.y,unityAttPos.z,1),vertIdx);
+                        shape.SetControlPointAt(new FbxVector4(unityAttPos.x,unityAttPos.y,unityAttPos.z,1),vertIdx);
                     }
-
-                    shapeKeyChannel1.AddTargetShape(shape1);
-                    blendShape.AddBlendShapeChannel(shapeKeyChannel1);
+                    channel.AddTargetShape(shape);
+                    blendShape.AddBlendShapeChannel(channel);
                 }
                 fbxMesh.AddDeformer(blendShape);
             }

--- a/Assets/Scripts/Pal3.ResourceViewer/FBXExporter.cs
+++ b/Assets/Scripts/Pal3.ResourceViewer/FBXExporter.cs
@@ -1,0 +1,132 @@
+﻿using Autodesk.Fbx;
+using Pal3.Core.DataReader.Mv3;
+using Pal3.Core.Primitives;
+using UnityEngine.SceneManagement;
+
+namespace Pal3.ResourceViewer
+{
+    public class FBXExporter
+    {
+        public void ExportMv3File(Mv3File mv3File)
+        {
+
+            FbxManager fbxManager = FbxManager.Create();
+            FbxScene fbxScene = FbxScene.Create(fbxManager, "MyScene");
+            
+            for (int meshIdx = 0;meshIdx < mv3File.Meshes.Length;meshIdx++)
+            {
+                FbxNode meshNode = FbxNode.Create(fbxScene,"MyMesh");
+                FbxMesh mesh = FbxMesh.Create(fbxScene,"MyMeshGeometry");
+                
+                Mv3Mesh mv3Mesh = mv3File.Meshes[meshIdx];
+                ExportMv3Mesh(mesh,mv3Mesh);
+                //ExportMv3Anim(fbxManager,fbxScene, mesh, mv3Mesh);
+                ExportMv3AnimV2(fbxManager,fbxScene, mesh, mv3Mesh);
+
+                meshNode.SetNodeAttribute(mesh);
+                fbxScene.GetRootNode().AddChild(meshNode);
+            }
+
+
+            // @miao @todo
+            var exporter = Autodesk.Fbx.FbxExporter.Create(fbxManager,"");
+            var settings = FbxIOSettings.Create(fbxManager, "test");
+            settings.SetBoolProp("Shape",true);
+            settings.SetBoolProp("ShapeAttributes",true);
+            settings.SetBoolProp("ShapeAttributesValues",true);
+            settings.SetBoolProp("ShapeAnimation",true);
+            
+            
+            
+            
+            //exporter.Initialize("ayy_test.fbx", -1, fbxManager.GetIOSettings());
+            exporter.Initialize("ayy_test.fbx", -1, settings);
+
+            exporter.Export(fbxScene);
+        }
+
+        private void ExportMv3Mesh(FbxMesh destMesh, Mv3Mesh mv3Mesh)
+        {
+            // vertices
+            int vertexCount = mv3Mesh.KeyFrames[0].GameBoxVertices.Length;
+            
+            destMesh.InitControlPoints(vertexCount);    // position
+            FbxLayerElementUV uvElement = destMesh.CreateElementUV("MyUVs");  // uv
+            FbxLayerElementNormal normalElement = destMesh.CreateElementNormal(); // normal
+            
+            for (int vertIdx = 0;vertIdx < vertexCount;vertIdx++)
+            {
+                // vert position
+                GameBoxVector3 attPos = mv3Mesh.KeyFrames[0].GameBoxVertices[vertIdx];
+                destMesh.SetControlPointAt(new FbxVector4(attPos.X,attPos.Y,attPos.Z,1),vertIdx);    
+                
+                // vert UV
+                GameBoxVector2 attUV = mv3Mesh.Uvs[vertIdx];
+                uvElement.GetDirectArray().SetAt(vertIdx,new FbxVector2(attUV.X,attUV.Y));
+                
+                // normal
+                GameBoxVector3 attNormal = mv3Mesh.GameBoxNormals[vertIdx];
+                normalElement.GetDirectArray().SetAt(vertIdx,new FbxVector4(attNormal.X,attNormal.Y,attNormal.Z,0.0));
+            }
+            
+            // Faces
+            int faceCount = mv3Mesh.GameBoxTriangles.Length / 3;
+            for (int faceIdx = 0;faceIdx < faceCount;faceIdx++)
+            {
+                int vertIdx = mv3Mesh.GameBoxTriangles[faceIdx * 3];
+                destMesh.BeginPolygon();
+                destMesh.AddPolygon(vertIdx);
+                destMesh.AddPolygon(vertIdx + 1);
+                destMesh.AddPolygon(vertIdx + 2);
+                destMesh.EndPolygon();
+            }
+        }
+        
+        private void ExportMv3Anim(FbxManager fbxManager,FbxScene fbxScene,FbxMesh fbxMesh,Mv3Mesh mv3Mesh)
+        {
+            FbxBlendShapeChannel blendShapeChannel = FbxBlendShapeChannel.Create(fbxScene,"MyBlendShapeChannel");
+            FbxBlendShape blendShape = FbxBlendShape.Create(fbxScene,"MyBlendShape");
+            blendShape.AddBlendShapeChannel(blendShapeChannel);
+            fbxMesh.AddDeformer(blendShape);
+
+            int frameCount = mv3Mesh.KeyFrames.Length;
+            int vertexCount = mv3Mesh.KeyFrames[0].GameBoxVertices.Length;
+            for (int frameIndex = 0;frameIndex < frameCount;frameIndex++)
+            {
+                FbxShape shape = FbxShape.Create(fbxScene,"MyShape_" + frameIndex);
+                for (int vertIdx = 0;vertIdx < vertexCount;vertIdx++) 
+                {
+                    GameBoxVector3 pos = mv3Mesh.KeyFrames[frameIndex].GameBoxVertices[vertIdx];
+                    shape.SetControlPointAt(new FbxVector4(pos.X,pos.Y,pos.Z,1.0),vertIdx);
+                }
+                blendShapeChannel.AddTargetShape(shape);
+            }
+
+
+        }
+
+
+        private void ExportMv3AnimV2(FbxManager fbxManager, FbxScene fbxScene, FbxMesh fbxMesh, Mv3Mesh mv3Mesh)
+        {
+            //FbxBlendShape blendShape = FbxBlendShape.Create(fbxScene, "MyBlendShape");
+            //fbxMesh.AddDeformer(blendShape);
+
+            // var deformer = FbxDeformer.Create(fbxManager, "test11");
+            // fbxMesh.AddDeformer(deformer);
+
+            
+            FbxBlendShape deformer = fbxMesh.GetBlendShapeDeformer(0);
+            if (deformer == null)
+            {
+                deformer = FbxBlendShape.Create(fbxMesh, "MyDefoner");
+            }
+
+            FbxBlendShapeChannel channel = FbxBlendShapeChannel.Create(deformer,"MyChannel");
+            // channel.AddTargetShape()
+
+
+            deformer.AddBlendShapeChannel(channel);
+        }
+
+    }
+}

--- a/Assets/Scripts/Pal3.ResourceViewer/FBXExporter.cs
+++ b/Assets/Scripts/Pal3.ResourceViewer/FBXExporter.cs
@@ -63,8 +63,12 @@ namespace Pal3.ResourceViewer
             
             destMesh.InitControlPoints(vertexCount);    // position
             FbxLayerElementUV uvElement = destMesh.CreateElementUV("MyUVs");  // uv
-            FbxLayerElementNormal normalElement = destMesh.CreateElementNormal(); // normal
+            uvElement.SetMappingMode(FbxLayerElement.EMappingMode.eByControlPoint);
+            uvElement.SetReferenceMode(FbxLayerElement.EReferenceMode.eDirect);
+            uvElement.GetDirectArray().SetCount(vertexCount);
             
+            FbxLayerElementNormal normalElement = destMesh.CreateElementNormal(); // normal
+            normalElement.GetDirectArray().SetCount(vertexCount);
             for (int vertIdx = 0;vertIdx < vertexCount;vertIdx++)
             {
                 // vert position
@@ -75,11 +79,16 @@ namespace Pal3.ResourceViewer
                 // vert UV
                 GameBoxVector2 attUV = mv3Mesh.Uvs[vertIdx];
                 uvElement.GetDirectArray().SetAt(vertIdx,new FbxVector2(attUV.X,attUV.Y));
-                
+
                 // normal
                 GameBoxVector3 attNormal = mv3Mesh.GameBoxNormals[vertIdx];
                 normalElement.GetDirectArray().SetAt(vertIdx,new FbxVector4(attNormal.X,attNormal.Y,attNormal.Z,0.0));
             }
+            
+            int cnt = uvElement.GetDirectArray().GetCount();
+            Debug.Log("uv element cnt:" + cnt);
+            
+            
             
             // Faces
             int faceCount = mv3Mesh.GameBoxTriangles.Length / 3;

--- a/Assets/Scripts/Pal3.ResourceViewer/FBXExporter.cs.meta
+++ b/Assets/Scripts/Pal3.ResourceViewer/FBXExporter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c3290fb5c0b640be8229df04ae2b473c
+timeCreated: 1723337297

--- a/Assets/Scripts/Pal3.ResourceViewer/GameResourceViewer.cs
+++ b/Assets/Scripts/Pal3.ResourceViewer/GameResourceViewer.cs
@@ -570,8 +570,48 @@ namespace Pal3.ResourceViewer
         
         private void ExportFbx()
         {
-            _enableExportFbx = !_enableExportFbx;
+            string directoryPath = EditorUtility.SaveFolderPanel("选择Fbx目标目录", "", "");
+            for (int i = 0;i < _mv3Files.Count;i++)
+            {
+                string filePath = _mv3Files[i];
+                Mv3File mv3File = _resourceProvider.GetGameResourceFile<Mv3File>(filePath);
+                string targetPath = Path.Combine(directoryPath,filePath);
+                string targetDir = Path.GetDirectoryName(targetPath);
+                if (!Directory.Exists(targetDir))
+                {
+                    Directory.CreateDirectory(targetDir);
+                }
+
+                _fbxExporter.ExportMv3File(mv3File,targetPath);
+            }
+            // List<string> mv3FilePaths = FindMv3FilesRecursively(directoryPath);
+
+            
+            Debug.Log("test");
         }
+
+        // private List<string> FindMv3FilesRecursively(string directoryPath)
+        // {
+        //     List<string> mv3FilePaths = new List<string>();
+        //
+        //     try
+        //     {
+        //         string[] files = Directory.GetFiles(directoryPath, "*.mv3", SearchOption.AllDirectories);
+        //         mv3FilePaths.AddRange(files);
+        //
+        //         string[] subdirectories = Directory.GetDirectories(directoryPath);
+        //         foreach (string subdirectory in subdirectories)
+        //         {
+        //             mv3FilePaths.AddRange(FindMv3FilesRecursively(subdirectory));
+        //         }
+        //     }
+        //     catch (Exception ex)
+        //     {
+        //         Console.WriteLine($"Error: {ex.Message}");
+        //     }
+        //     
+        //     return mv3FilePaths;
+        // }
 
         private bool _isMovieCpkMounted = false;
         private IEnumerator ExtractAllCpkArchivesInternalAsync(string outputFolderPath)

--- a/Assets/Scripts/Pal3.ResourceViewer/GameResourceViewer.cs
+++ b/Assets/Scripts/Pal3.ResourceViewer/GameResourceViewer.cs
@@ -59,6 +59,7 @@ namespace Pal3.ResourceViewer
         [SerializeField] private Button randomMp3Button;
         [SerializeField] private Button randomMovButton;
         [SerializeField] private Button extractAllCpkFilesButton;
+        [SerializeField] private Button exportFbxButton;
         [SerializeField] private AudioSource audioSource;
         [SerializeField] private FpsCounter fpsCounter;
 
@@ -79,6 +80,9 @@ namespace Pal3.ResourceViewer
 
         private int _codePage;
         //private HashSet<char> _charSet;
+        
+        private bool _enableExportFbx = true;
+        private Pal3.ResourceViewer.FBXExporter _fbxExporter = new FBXExporter();
 
         private void OnEnable()
         {
@@ -128,6 +132,7 @@ namespace Pal3.ResourceViewer
 
             #if UNITY_EDITOR
             extractAllCpkFilesButton.onClick.AddListener(ExtractAllCpkArchives);
+            exportFbxButton.onClick.AddListener(ExportFbx);
             #else
             extractAllCpkFilesButton.interactable = false;
             #endif
@@ -378,6 +383,11 @@ namespace Pal3.ResourceViewer
 
                 Camera.main!.transform.LookAt(new Vector3(0, 2, 0));
 
+                if (_enableExportFbx)
+                {
+                    _fbxExporter.ExportMv3File(mv3File);
+                }
+
                 return true;
             }
             catch (Exception ex)
@@ -556,6 +566,11 @@ namespace Pal3.ResourceViewer
             extractAllCpkFilesButton.interactable = false;
             consoleTextUI.text = "正在解包全部CPK文件，请稍等...";
             StartCoroutine(ExtractAllCpkArchivesInternalAsync(outputFolderPath));
+        }
+        
+        private void ExportFbx()
+        {
+            _enableExportFbx = !_enableExportFbx;
         }
 
         private bool _isMovieCpkMounted = false;

--- a/Assets/Scripts/Pal3.ResourceViewer/GameResourceViewer.cs
+++ b/Assets/Scripts/Pal3.ResourceViewer/GameResourceViewer.cs
@@ -81,7 +81,6 @@ namespace Pal3.ResourceViewer
         private int _codePage;
         //private HashSet<char> _charSet;
         
-        private bool _enableExportFbx = true;
         private Pal3.ResourceViewer.FBXExporter _fbxExporter = new FBXExporter();
 
         private void OnEnable()
@@ -382,11 +381,6 @@ namespace Pal3.ResourceViewer
                 consoleTextUI.text = $"{filePath}";
 
                 Camera.main!.transform.LookAt(new Vector3(0, 2, 0));
-
-                if (_enableExportFbx)
-                {
-                    _fbxExporter.ExportMv3File(mv3File);
-                }
 
                 return true;
             }

--- a/Assets/Scripts/Pal3.ResourceViewer/Pal3.ResourceViewer.asmdef
+++ b/Assets/Scripts/Pal3.ResourceViewer/Pal3.ResourceViewer.asmdef
@@ -7,7 +7,8 @@
         "GUID:077e41948865f464a8105d046a0fdfe0",
         "GUID:3de88c88fbbb8f944b9210d496af9762",
         "GUID:6055be8ebefd69e48b49212b09b47b2f",
-        "GUID:75469ad4d38634e559750d17036d5f7c"
+        "GUID:75469ad4d38634e559750d17036d5f7c",
+        "GUID:2b82e46c4ca0a4eb697ab8ccdfb39af1"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -17,5 +18,6 @@
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],
-    "noEngineReferences": false
+    "noEngineReferences": false,
+    "allowUnsafeCode": true
 }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -3,6 +3,7 @@
     "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity",
     "com.unity.ai.navigation": "1.1.5",
     "com.unity.feature.development": "1.0.1",
+    "com.unity.formats.fbx": "4.2.1",
     "com.unity.ide.rider": "3.0.31",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,5 +1,12 @@
 {
   "dependencies": {
+    "com.autodesk.fbx": {
+      "version": "4.2.1",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.github-glitchenzo.nugetforunity": {
       "version": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity",
       "depth": 0,
@@ -43,6 +50,16 @@
         "com.unity.test-framework": "1.1.33",
         "com.unity.testtools.codecoverage": "1.2.5"
       }
+    },
+    "com.unity.formats.fbx": {
+      "version": "4.2.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.timeline": "1.7.1",
+        "com.autodesk.fbx": "4.2.1"
+      },
+      "url": "https://packages.unity.com"
     },
     "com.unity.ide.rider": {
       "version": "3.0.31",


### PR DESCRIPTION
在 ResourceViewer场景里, 新增了一个 把所有 mv3 导出为通用的 Fbx 的按钮.
点之后选择一个路径, 会把所有的 mv3导出为 fbx  . 因为每个 mv3都会导出, 时间会比较长
![image](https://github.com/user-attachments/assets/7693ee9e-c4f7-49df-b8f0-aeb4c20efe1a)

导出的 fbx包含了 mv3所有的顶点动画. 
用 blender 打开,可以看到 所有顶点动画关键帧, 
都被记录在 了 BlendShape 的 Shape Key 里.  
在 blender 里 能比较方便的 播放 
![image](https://github.com/user-attachments/assets/c40fb88c-7182-4799-96cb-c00e11b47e72)

https://github.com/user-attachments/assets/9bce67d5-02e2-4e5a-afc9-fcf0f1bccf7f


这种 Fbx 可以直接被 unity 引擎使用.
Unity 引擎导入这种 Fbx 之后, 会自带 BlendShape 控制器 ,
动态控制 这些就能在 unity里直接播动画 
![image](https://github.com/user-attachments/assets/1ff30b07-6b9d-460e-a7fb-7abbfa8c42f2)
https://github.com/user-attachments/assets/dfb59d22-7d3f-4565-a65c-0c73b09fe1db


**目的还是用于方便二创.  (比如不依赖游戏原始文件,直接用fbx+贴图就可以用其他游戏引擎做开发. 或者在DCC里做动画)**
**不强求 merge, 看你觉得是不是需要~**

